### PR TITLE
fix: 修复单位斜向移动时动画朝向与移动方向不匹配

### DIFF
--- a/src/engine/renderable/entity/Vehicle.ts
+++ b/src/engine/renderable/entity/Vehicle.ts
@@ -613,7 +613,7 @@ export class Vehicle {
     updateShapeFrame(t, i, r) {
         if (this.shpRenderable && this.shpAnimRunner) {
             let e;
-            var s = this.objectArt.facings, a = Math.round((((45 - t + 360) % 360) / 360) * s) % s, s = this.shpAnimRunner.animation.getCurrentFrame();
+            var s = this.objectArt.facings, a = Math.round((((t - 45 + 360) % 360) / 360) * s) % s, s = this.shpAnimRunner.animation.getCurrentFrame();
             (e = r
                 ? this.objectArt.startFiringFrame +
                     this.objectArt.firingFrames * a +

--- a/src/game/math/GameMath.ts
+++ b/src/game/math/GameMath.ts
@@ -505,9 +505,9 @@ export class GameMath {
                 if (Number.isFinite(y) && y !== 0) {
                     return this.atan2FiniteNonZero(y, x);
                 }
-                return this.signIncZero(y) * Math.PI * 0.5;
+                return this.signIncZero(y) * (x < 0 ? Math.PI : 0);
             }
-            return this.signIncZero(y) * (this.signIncZero(x) < 0 ? Math.PI : 0);
+            return this.signIncZero(y) * Math.PI * 0.5;
         }
         return Math.sign(y) * Math.PI * (Math.sign(x) > 0 ? 0.25 : 0.75);
     }


### PR DESCRIPTION
## Summary

- 修复了所有单位（步兵、载具、船只）在屏幕对角线方向移动时，动画朝向与实际移动方向不一致的 bug
- 根本原因：`GameMath.atan2()` 中 `y=0` 和 `x=0` 两种边界情况的返回值写反了，导致沿地图网格纯水平/垂直方向移动时角度计算错误
- 同时修正了 `Vehicle.ts` 中 SHP 帧选择公式，使其与 `Infantry.ts` 的正确公式保持一致

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/game/math/GameMath.ts` | 交换 `atan2()` 边界情况的返回值 |
| `src/engine/renderable/entity/Vehicle.ts` | 帧选择公式 `(45-t)` → `(t-45)` |

## 问题分析

`GameMath.atan2(y, x)` 在输入分量为 0 时返回错误值：

| 输入 | 修复前(错误) | 修复后(正确) | 标准 Math.atan2 |
|------|-------------|-------------|----------------|
| `atan2(0, 1)` | π/2 (90°) | 0 | 0 |
| `atan2(0, -1)` | π/2 (90°) | π (180°) | π (180°) |
| `atan2(1, 0)` | 0 | π/2 (90°) | π/2 (90°) |
| `atan2(-1, 0)` | 0 | -π/2 (-90°) | -π/2 (-90°) |

对角线方向（两个分量都非零）走 `atan2FiniteNonZero` 路径，不受影响，因此上下左右移动正常而斜向移动异常。

## Test plan

- [x] 步兵斜向移动朝向正确
- [x] 载具斜向移动朝向正确
- [x] 船只斜向移动朝向正确
- [x] 上下左右移动仍然正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)