### PR TITLE
fix: 改善 VXL 模型光照偏暗问题

### DIFF
--- a/src/engine/renderable/entity/Aircraft.ts
+++ b/src/engine/renderable/entity/Aircraft.ts
@@ -170,7 +170,7 @@ export class Aircraft {
         this.extraLight = new THREE.Vector3().copy(this.baseExtraLight);
     }
     private updateBaseLight(): void {
-        this.baseExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile) + this.rules.audioVisual.extraAircraftLight);
+        this.baseExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile) + this.rules.audioVisual.extraAircraftLight);
     }
     updateLighting(): void {
         this.plugins.forEach((plugin) => plugin.updateLighting?.());

--- a/src/engine/renderable/entity/Building.ts
+++ b/src/engine/renderable/entity/Building.ts
@@ -272,7 +272,7 @@ export class Building {
         (this.baseShpExtraLight = this.lighting
             .compute(this.objectArt.lightingType, this.gameObject.tile)
             .addScalar(-1)),
-            (this.baseVxlExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile)));
+            (this.baseVxlExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile)));
     }
     updateLighting() {
         this.updateBaseLight(),

--- a/src/engine/renderable/entity/Debris.ts
+++ b/src/engine/renderable/entity/Debris.ts
@@ -111,7 +111,7 @@ export class Debris {
         this.baseShpExtraLight = this.lighting
             .compute(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
             .addScalar(-1);
-        this.baseVxlExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
+        this.baseVxlExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
         this.vxlExtraLight = new THREE.Vector3().copy(this.baseVxlExtraLight);
         this.shpExtraLight = new THREE.Vector3().copy(this.baseShpExtraLight);
         this.withPosition = new WithPosition();
@@ -124,7 +124,7 @@ export class Debris {
         this.baseShpExtraLight = this.lighting
             .compute(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
             .addScalar(-1);
-        this.baseVxlExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
+        this.baseVxlExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
         this.vxlExtraLight.copy(this.baseVxlExtraLight);
         this.shpExtraLight.copy(this.baseShpExtraLight);
     }
@@ -156,7 +156,7 @@ export class Debris {
         const elevation = this.gameObject.tile.z + this.gameObject.tileElevation;
         if (this.lastElevation === undefined || this.lastElevation !== elevation) {
             this.lastElevation = elevation;
-            this.baseVxlExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
+            this.baseVxlExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
             this.baseShpExtraLight = this.lighting
                 .compute(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
                 .addScalar(-1);

--- a/src/engine/renderable/entity/Projectile.ts
+++ b/src/engine/renderable/entity/Projectile.ts
@@ -94,7 +94,7 @@ export class Projectile {
     updateLighting(): void {
         this.plugins.forEach((plugin) => plugin.updateLighting?.());
         if (this.objectArt.isVoxel) {
-            this.extraLight.setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
+            this.extraLight.setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation));
         }
         else {
             this.extraLight

--- a/src/engine/renderable/entity/Vehicle.ts
+++ b/src/engine/renderable/entity/Vehicle.ts
@@ -250,7 +250,7 @@ export class Vehicle {
             .compute(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
             .addScalar(-1)
             .addScalar(this.rules.audioVisual.extraUnitLight)),
-            (this.baseVxlExtraLight = new THREE.Vector3().setScalar(1 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation) + this.rules.audioVisual.extraUnitLight));
+            (this.baseVxlExtraLight = new THREE.Vector3().setScalar(Math.PI * 1.5 + this.lighting.computeNoAmbient(this.objectArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation) + this.rules.audioVisual.extraUnitLight));
     }
     registerPlugin(e) {
         this.plugins.push(e);


### PR DESCRIPTION
## Summary

- VXL 模型（坦克、船只、飞机、建筑等）整体偏暗，看起来像笼罩在阴影中
- 原因：Three.js 的 `BRDF_Lambert` 在光照计算中引入了 `1/π` 因子，而 RA2 原版的调色板颜色不是按物理渲染设计的，导致亮度衰减
- 将 VXL `extraLight` 基础值从 `1` 提升到 `Math.PI * 1.5`（≈4.71），补偿 Lambert BRDF 衰减

## 改动文件

| 文件 | 改动 |
|------|------|
| `Vehicle.ts` | extraLight 基础值 `1` → `Math.PI * 1.5` |
| `Aircraft.ts` | 同上 |
| `Building.ts` | 同上 |
| `Debris.ts` | 同上（3处） |
| `Projectile.ts` | 同上 |

## 效果说明

当前效果相比之前有明显改善，VXL 单位上的阴影明显变浅。但与红警2原版效果仍存在一定差异，后续可根据需要继续微调 `Math.PI * 1.5` 这个系数，或考虑从 shader 层面修改 BRDF 计算以更精确地匹配原版光照模型。

## Test plan

- [x] 坦克亮度明显改善，不再像之前那样偏暗
- [x] 船只、飞机等 VXL 单位同样改善
- [x] SHP 精灵单位（步兵等）不受影响