### PR TITLE
fix: 修复幻影坦克伪装显示逻辑

### DIFF
--- a/src/engine/renderable/entity/plugin/VehicleDisguisePlugin.ts
+++ b/src/engine/renderable/entity/plugin/VehicleDisguisePlugin.ts
@@ -2,6 +2,14 @@ import { MapSpriteTranslation } from "@/engine/renderable/MapSpriteTranslation";
 import { ShpRenderable } from "@/engine/renderable/ShpRenderable";
 import { ObjectType } from "@/engine/type/ObjectType";
 import * as THREE from "three";
+
+// Fade out/in duration in milliseconds
+const FADE_OUT_MS = 200;
+const FADE_IN_MS = 200;
+// Allied blink: show tree then show tank, repeating
+const BLINK_TREE_MS = 3000;
+const BLINK_TANK_MS = 1500;
+
 export class VehicleDisguisePlugin {
     private gameObject: any;
     private disguiseTrait: any;
@@ -15,12 +23,23 @@ export class VehicleDisguisePlugin {
     private lighting: any;
     private gameSpeed: any;
     private useSpriteBatching: boolean;
-    private lastRenderDisguised: boolean = false;
+
     private canSeeThroughDisguise: boolean = false;
     private lastDisguised?: boolean;
     private disguisedAt?: number;
     private disguiseObj?: THREE.Object3D;
     private disguiseRenderable?: ShpRenderable;
+
+    // Sequential fade state:
+    // showingTree = which form is currently rendered
+    // wantTree    = which form we want to show
+    // opacity     = current opacity of the displayed form (0..1)
+    // When showingTree !== wantTree, we fade out; at 0 we swap; then fade in.
+    private showingTree: boolean = false;
+    private wantTree: boolean = false;
+    private opacity: number = 1;
+    private lastTime: number = 0;
+
     constructor(gameObject: any, disguiseTrait: any, localPlayer: any, alliances: any, renderable: any, art: any, imageFinder: any, theater: any, camera: any, lighting: any, gameSpeed: any, useSpriteBatching: boolean) {
         this.gameObject = gameObject;
         this.disguiseTrait = disguiseTrait;
@@ -35,53 +54,142 @@ export class VehicleDisguisePlugin {
         this.gameSpeed = gameSpeed;
         this.useSpriteBatching = useSpriteBatching;
     }
+
     onCreate(): void { }
+
     update(time: number): void {
-        if (!this.gameObject.isDestroyed &&
-            !this.gameObject.warpedOutTrait.isActive()) {
-            let isDisguised = this.disguiseTrait.isDisguised();
-            if (isDisguised !== this.lastDisguised) {
-                this.lastDisguised = isDisguised;
-                this.disguisedAt = isDisguised ? time : undefined;
+        if (this.gameObject.isDestroyed ||
+            this.gameObject.warpedOutTrait.isActive()) {
+            return;
+        }
+
+        const dt = this.lastTime > 0 ? time - this.lastTime : 16;
+        this.lastTime = time;
+
+        const isTraitDisguised = this.disguiseTrait.isDisguised();
+
+        // Track trait state transitions
+        if (isTraitDisguised !== this.lastDisguised) {
+            this.lastDisguised = isTraitDisguised;
+            this.disguisedAt = isTraitDisguised ? time : undefined;
+        }
+
+        const localPlayer = this.localPlayer.value;
+
+        // Update detection status
+        if (isTraitDisguised) {
+            this.canSeeThroughDisguise =
+                !localPlayer ||
+                this.alliances.haveSharedIntel(localPlayer, this.gameObject.owner) ||
+                !!localPlayer.sharedDetectDisguiseTrait?.has(this.gameObject);
+        }
+
+        // --- Decide desired form ---
+        if (!isTraitDisguised) {
+            // Moving / firing / cooldown → tank
+            this.wantTree = false;
+        } else if (!this.canSeeThroughDisguise) {
+            // Enemy view → always tree
+            this.wantTree = true;
+        } else if (localPlayer?.sharedDetectDisguiseTrait?.has(this.gameObject)) {
+            // Detected by detector → always tank
+            this.wantTree = false;
+        } else {
+            // Allied / own view → blink
+            const elapsed = time - (this.disguisedAt ?? time);
+            const phase = elapsed % (BLINK_TREE_MS + BLINK_TANK_MS);
+            this.wantTree = phase < BLINK_TREE_MS;
+        }
+
+        // --- Animate sequential fade ---
+        if (this.showingTree !== this.wantTree) {
+            if (this.showingTree) {
+                // Tree → Tank: fade out tree, then instantly show tank
+                this.opacity -= dt / FADE_OUT_MS;
+                if (this.opacity <= 0) {
+                    this.opacity = 1; // tank appears instantly
+                    this.showingTree = false;
+                }
+            } else {
+                // Tank → Tree: fade out tank, then fade in tree
+                this.opacity -= dt / FADE_OUT_MS;
+                if (this.opacity <= 0) {
+                    this.opacity = 0;
+                    this.showingTree = true;
+                }
             }
-            let localPlayer = this.localPlayer.value;
-            if (isDisguised) {
-                this.canSeeThroughDisguise =
-                    !localPlayer ||
-                        this.alliances.haveSharedIntel(localPlayer, this.gameObject.owner) ||
-                        !!localPlayer.sharedDetectDisguiseTrait?.has(this.gameObject);
-                if (isDisguised && this.canSeeThroughDisguise) {
-                    isDisguised =
-                        !localPlayer?.sharedDetectDisguiseTrait?.has(this.gameObject) &&
-                            Math.floor(((time - this.disguisedAt!) * this.gameSpeed.value) / 1000) % 16 <= 3;
-                }
-                if (this.lastRenderDisguised !== isDisguised) {
-                    this.lastRenderDisguised = isDisguised;
-                    this.renderable.mainObj.visible = !isDisguised;
-                    this.renderable.posObj.visible = !isDisguised || this.canSeeThroughDisguise;
-                    if (this.disguiseObj) {
-                        this.disguiseObj.visible = false;
-                    }
-                    if (isDisguised) {
-                        let disguise = this.disguiseTrait.getDisguise();
-                        if (disguise.rules.type !== ObjectType.Terrain) {
-                            throw new Error("Unsupported disguise type " + ObjectType[disguise.rules.type]);
-                        }
-                        disguise = this.art.getObject(disguise.rules.name, ObjectType.Terrain);
-                        if (!this.disguiseObj) {
-                            this.disguiseObj = this.createDisguiseObj(disguise);
-                            this.renderable.get3DObject().add(this.disguiseObj);
-                        }
-                        this.disguiseObj.visible = true;
-                        const extraLight = this.lighting
-                            .compute(disguise.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
-                            .addScalar(-1);
-                        this.disguiseRenderable!.setExtraLight(extraLight);
-                    }
-                }
+        } else if (this.opacity < 1) {
+            // Fading in (only for tree appearing)
+            this.opacity += dt / FADE_IN_MS;
+            if (this.opacity > 1) this.opacity = 1;
+        }
+
+        // --- Apply visuals ---
+        // Ensure disguise 3D object exists when needed
+        if (this.showingTree && isTraitDisguised) {
+            this.ensureDisguiseObj();
+        }
+
+        if (this.showingTree) {
+            // Tree form active
+            if (this.renderable.mainObj) {
+                this.renderable.mainObj.visible = false;
+            }
+            this.renderable.posObj.visible = this.canSeeThroughDisguise;
+            if (this.disguiseObj) {
+                this.disguiseObj.visible = true;
+                this.disguiseRenderable?.setOpacity(this.opacity);
+            }
+            // Restore vehicle opacity in case it was faded
+            this.setMainVehicleOpacity(1);
+        } else {
+            // Tank form active
+            if (this.renderable.mainObj) {
+                this.renderable.mainObj.visible = true;
+            }
+            this.renderable.posObj.visible = true;
+            if (this.disguiseObj) {
+                this.disguiseObj.visible = false;
+            }
+            this.setMainVehicleOpacity(this.opacity);
+        }
+
+        // Update disguise lighting
+        if (this.disguiseObj?.visible && this.disguiseRenderable && isTraitDisguised) {
+            const disguise = this.disguiseTrait.getDisguise();
+            if (disguise?.rules.type === ObjectType.Terrain) {
+                const terrainArt = this.art.getObject(disguise.rules.name, ObjectType.Terrain);
+                const extraLight = this.lighting
+                    .compute(terrainArt.lightingType, this.gameObject.tile, this.gameObject.tileElevation)
+                    .addScalar(-1);
+                this.disguiseRenderable.setExtraLight(extraLight);
             }
         }
     }
+
+    private ensureDisguiseObj(): void {
+        if (this.disguiseObj) return;
+        const disguise = this.disguiseTrait.getDisguise();
+        if (!disguise || disguise.rules.type !== ObjectType.Terrain) return;
+        const terrainArt = this.art.getObject(disguise.rules.name, ObjectType.Terrain);
+        this.disguiseObj = this.createDisguiseObj(terrainArt);
+        this.renderable.get3DObject().add(this.disguiseObj);
+    }
+
+    private setMainVehicleOpacity(opacity: number): void {
+        if (this.renderable.vxlBuilders) {
+            for (const builder of this.renderable.vxlBuilders) {
+                builder.setOpacity(opacity);
+            }
+        }
+        if (this.renderable.shpRenderable) {
+            this.renderable.shpRenderable.setOpacity(opacity);
+        }
+        if (this.renderable.placeholder) {
+            this.renderable.placeholder.setOpacity(opacity);
+        }
+    }
+
     private createDisguiseObj(disguise: any): THREE.Object3D {
         const obj = new THREE.Object3D();
         obj.matrixAutoUpdate = false;
@@ -105,6 +213,7 @@ export class VehicleDisguisePlugin {
         this.disguiseRenderable = renderable;
         return obj;
     }
+
     updateLighting(): void {
         if (this.disguiseObj?.visible && this.disguiseRenderable) {
             const disguise = this.disguiseTrait.getDisguise();
@@ -119,22 +228,27 @@ export class VehicleDisguisePlugin {
             }
         }
     }
+
     onRemove(): void {
+        this.setMainVehicleOpacity(1);
         if (this.disguiseObj) {
             this.renderable.get3DObject().remove(this.disguiseObj);
             this.disguiseObj = undefined;
         }
     }
+
     getUiNameOverride(): string | undefined {
         if (this.gameObject.disguiseTrait?.hasTerrainDisguise() &&
             !this.canSeeThroughDisguise) {
             return "";
         }
     }
+
     shouldDisableHighlight(): boolean {
         return (!!this.gameObject.disguiseTrait?.hasTerrainDisguise() &&
             !this.canSeeThroughDisguise);
     }
+
     dispose(): void {
         this.disguiseRenderable?.dispose();
     }


### PR DESCRIPTION
## Summary
- 修复幻影坦克在移动/开火时仍显示树形态的bug（原代码在取消伪装时未恢复坦克模型可见性）
- 己方视角：静止伪装时在树和坦克形态间交替显示（3秒树 / 1.5秒坦克）
- 敌方视角：伪装时始终显示树形态
- 添加渐变过渡效果：坦克淡出后树渐入，树淡出后坦克瞬间出现，避免形态重叠

## Note
当前效果与红警2原版还存在一些差异，后续可继续调整过渡动画的时间参数和表现细节，使其更贴近原版效果。

## Test plan
- [x] 选择盟军，建造幻影坦克
- [x] 验证移动时显示坦克形态（不再显示树）
- [x] 验证开火时显示坦克形态
- [x] 验证静止时己方视角下树和坦克形态交替显示
- [x] 验证形态切换有渐变过渡效果，无重叠