### PR TITLE
fix: 修复矿石/桥覆盖地面单位的渲染层级及桥面点击通行问题

### DIFF
--- a/src/engine/renderable/entity/Overlay.ts
+++ b/src/engine/renderable/entity/Overlay.ts
@@ -269,6 +269,22 @@ export class Overlay {
                 const bridgeShadowSurface = this.createBridgeShadowSurface();
                 parent.add(bridgeShadowSurface);
             }
+            if (this.gameObject.isBridge()) {
+                const shapeMesh = mainRenderable.getShapeMesh();
+                if (shapeMesh) {
+                    (shapeMesh as THREE.Mesh).renderOrder = -1;
+                    const mat = (shapeMesh as THREE.Mesh).material as THREE.Material;
+                    mat.depthTest = false;
+                    mat.depthWrite = false;
+                }
+                const shadowMesh = mainRenderable.getShadowMesh();
+                if (shadowMesh) {
+                    (shadowMesh as THREE.Mesh).renderOrder = -1;
+                    const smat = (shadowMesh as THREE.Mesh).material as THREE.Material;
+                    smat.depthTest = false;
+                    smat.depthWrite = false;
+                }
+            }
             container.updateMatrix();
             parent.add(container);
         }

--- a/src/engine/renderable/entity/map/MapRenderable.ts
+++ b/src/engine/renderable/entity/map/MapRenderable.ts
@@ -82,8 +82,12 @@ export class MapRenderable {
         this.addObject(this.terrainLayer);
         this.overlayLayer = new MapSpriteBatchLayer("map_overlay_layer", [...this.rules.overlayRules.values()].filter((rule: any) => this.art.hasObject(rule.name, rule.type) &&
             !BridgeOverlayTypes.isBridge(this.rules.getOverlayId(rule.name))), (rule: any) => rule.rules.wall, this.theater, this.art, this.imageFinder, this.camera, this.lighting, shpAggregator);
+        this.overlayLayer.meshRenderOrder = -1;
+        this.overlayLayer.meshNoDepth = true;
         this.addObject(this.overlayLayer);
         this.smudgeLayer = new MapSpriteBatchLayer("map_smudge_layer", [...this.rules.smudgeRules.values()].filter((rule: any) => this.art.hasObject(rule.name, rule.type)), () => false, this.theater, this.art, this.imageFinder, this.camera, this.lighting, shpAggregator);
+        this.smudgeLayer.meshRenderOrder = -1;
+        this.smudgeLayer.meshNoDepth = true;
         this.addObject(this.smudgeLayer);
         this.mapRadiation.onChange.subscribe(this.handleRadChange);
     }

--- a/src/engine/renderable/entity/map/MapSpriteBatchLayer.ts
+++ b/src/engine/renderable/entity/map/MapSpriteBatchLayer.ts
@@ -35,6 +35,8 @@ export class MapSpriteBatchLayer {
     private batchedObjectRules: Set<any>;
     private aggregatedImageData: any;
     private target?: THREE.Object3D;
+    public meshRenderOrder: number = 0;
+    public meshNoDepth: boolean = false;
     constructor(label: string, batchedObjectRules: any[], spriteUseDepth: (obj: any) => number, theater: any, art: any, imageFinder: ImageFinder, camera: any, lighting: any, shpAggregator: ShpAggregator) {
         this.label = label;
         this.spriteUseDepth = spriteUseDepth;
@@ -110,7 +112,14 @@ export class MapSpriteBatchLayer {
             const palette = this.theater.getPalette(obj.art.paletteType, obj.art.customPaletteName);
             const newBuilder = new BatchShpBuilder(this.aggregatedImageData.file, palette, this.camera, this.textureCache, undefined, undefined, undefined, Coords.ISO_WORLD_SCALE);
             builders.push(newBuilder);
-            this.get3DObject()!.add(newBuilder.build());
+            const mesh = newBuilder.build();
+            mesh.renderOrder = this.meshRenderOrder;
+            if (this.meshNoDepth) {
+                const mat = mesh.material as THREE.Material;
+                mat.depthTest = false;
+                mat.depthWrite = false;
+            }
+            this.get3DObject()!.add(mesh);
             availableBuilder = newBuilder;
         }
         const mainSpec = this.buildBatchShpSpec(obj, this.aggregatedImageData);
@@ -123,7 +132,14 @@ export class MapSpriteBatchLayer {
                     throw new Error("Not implemented");
                 const newShadowBuilder = new BatchShpBuilder(this.aggregatedImageData.file, ShadowRenderable.getOrCreateShadowPalette(), this.camera, this.textureCache, 0.5, true, undefined, Coords.ISO_WORLD_SCALE);
                 this.shadowBatchShpBuilders.push(newShadowBuilder);
-                this.get3DObject()!.add(newShadowBuilder.build());
+                const shadowMesh = newShadowBuilder.build();
+                shadowMesh.renderOrder = this.meshRenderOrder;
+                if (this.meshNoDepth) {
+                    const mat = shadowMesh.material as THREE.Material;
+                    mat.depthTest = false;
+                    mat.depthWrite = false;
+                }
+                this.get3DObject()!.add(shadowMesh);
                 shadowBuilder = newShadowBuilder;
             }
             shadowSpec = this.buildShadowBatchShpSpec(mainSpec, this.aggregatedImageData);

--- a/src/engine/renderable/entity/map/MapTileLayer.ts
+++ b/src/engine/renderable/entity/map/MapTileLayer.ts
@@ -175,6 +175,7 @@ export class MapTileLayer {
         const mesh = new (THREE as any).Mesh(mergedGeometry, material);
         mesh.matrixAutoUpdate = false;
         mesh.frustumCulled = false;
+        mesh.renderOrder = -2;
         try {
             const mapTex: any = (material as any).map;
             const palTex: any = (material as any).uniforms?.palette?.value;

--- a/src/game/Target.ts
+++ b/src/game/Target.ts
@@ -27,6 +27,9 @@ export class Target {
             if (tile.landType === LandType.Tiberium) {
                 this.isOre = true;
             }
+            if (tile.onBridgeLandType !== undefined) {
+                this.bridge = tileOccupation.getBridgeOnTile(tile);
+            }
             this.tile = tile;
         }
     }


### PR DESCRIPTION
## Summary

- 修复矿石（ore）和弹坑（smudge）覆盖地面单位的渲染层级问题
- 修复桥面覆盖过桥单位的渲染层级问题
- 修复点击桥面位置无法让单位通行的问题（桥面位置被误判为水面）

## 问题原因

矿石和桥都是 flat sprite，与单位的 billboard sprite 在相机空间中处于相同深度，导致 z-fighting。原来的深度测试无法正确区分地面覆盖物和单位的前后关系。

桥面点击问题是因为当光线投射未命中桥的 3D 实体时，`Target` 没有检测 tile 上的桥信息，导致移动命令使用地面层级（水面）而非桥面层级。

## 解决方案

采用三层渲染分离策略：
1. **地形 tiles**（`renderOrder = -2`）：最先渲染，写入深度缓冲
2. **overlay/smudge/桥**（`renderOrder = -1`）：禁用 `depthTest` 和 `depthWrite`，始终绘制在地形之上，不影响深度缓冲
3. **单位**（`renderOrder = 0`，默认）：仅与地形深度做比较，矿石/桥不参与深度测试

桥面通行修复：在 `Target` 构造函数中，当未检测到实体时检查 `tile.onBridgeLandType`，自动识别桥并设置桥引用。

## 改动文件

| 文件 | 改动 |
|------|------|
| `MapTileLayer.ts` | 地形 mesh 设置 `renderOrder = -2` |
| `MapSpriteBatchLayer.ts` | 新增 `meshRenderOrder` 和 `meshNoDepth` 属性 |
| `MapRenderable.ts` | overlay/smudge 层启用分层渲染 |
| `Overlay.ts` | 桥 sprite 禁用深度测试/写入 |
| `Target.ts` | 点击空白桥面 tile 时自动检测桥 |

## Test plan

- [x] 矿车在矿石上移动时不再被矿石覆盖
- [x] 单位过桥时不再被桥面覆盖
- [x] 点击桥面位置可以正常下达移动命令
- [x] 矿石/弹坑仍然正常显示在地形上
- [ ] 高架桥下方的单位渲染正常