### PR TITLE
fix: 修复4个游戏机制的bug，附演示视频

### DIFF
--- a/src/game/action/OrderUnitsAction.ts
+++ b/src/game/action/OrderUnitsAction.ts
@@ -273,15 +273,7 @@ export class OrderUnitsAction extends Action {
                 next: undefined
             };
             if (waypointPaths.length === 0) {
-                const pendingLoopOrders = new Map();
-                for (const order of orders) {
-                    const unit = order.sourceObject;
-                    if (!pendingLoopOrders.has(unit)) {
-                        pendingLoopOrders.set(unit, []);
-                    }
-                    pendingLoopOrders.get(unit).push(order);
-                }
-                const waypointPath = { units: units, waypoints: [waypoint], pendingLoopOrders: pendingLoopOrders };
+                const waypointPath = { units: units, waypoints: [waypoint] };
                 units.forEach((unit: any) => {
                     unit.unitOrderTrait.waypointPath = waypointPath;
                 });
@@ -290,26 +282,6 @@ export class OrderUnitsAction extends Action {
                 const existingPath = waypointPaths[0];
                 existingPath.waypoints[existingPath.waypoints.length - 1].next = waypoint;
                 existingPath.waypoints.push(waypoint);
-                if (!existingPath.pendingLoopOrders) {
-                    existingPath.pendingLoopOrders = new Map();
-                }
-                for (const order of orders) {
-                    const unit = order.sourceObject;
-                    if (!existingPath.pendingLoopOrders.has(unit)) {
-                        existingPath.pendingLoopOrders.set(unit, []);
-                    }
-                    existingPath.pendingLoopOrders.get(unit).push(order);
-                }
-                if (existingPath.waypoints.length >= 2 &&
-                    waypoint.target.equals(existingPath.waypoints[0].target)) {
-                    existingPath.loop = true;
-                    existingPath.loopWaypoints = existingPath.waypoints.map((wp: any) => ({
-                        orderType: wp.orderType,
-                        target: wp.target,
-                        terminal: wp.terminal,
-                    }));
-                    existingPath.loopOrders = existingPath.pendingLoopOrders;
-                }
             }
         }
     }

--- a/src/game/gameobject/trait/UnitOrderTrait.ts
+++ b/src/game/gameobject/trait/UnitOrderTrait.ts
@@ -32,17 +32,9 @@ interface Order {
 interface Waypoint {
     next?: Waypoint;
 }
-interface WaypointBlueprint {
-    orderType: string;
-    target: any;
-    terminal: boolean;
-}
 interface WaypointPath {
     waypoints: Waypoint[];
     units: GameObject[];
-    loop?: boolean;
-    loopOrders?: Map<GameObject, any[]>;
-    loopWaypoints?: WaypointBlueprint[];
 }
 export class UnitOrderTrait implements NotifyTick, NotifyOwnerChange, NotifyTeleport {
     private gameObject: GameObject;
@@ -101,11 +93,7 @@ export class UnitOrderTrait implements NotifyTick, NotifyOwnerChange, NotifyTele
                         this.currentWaypoint = this.waypointPath.waypoints[0];
                     }
                     if (!this.currentWaypoint) {
-                        if (this.waypointPath.loop) {
-                            this.restartLoopPath();
-                        } else {
-                            this.cleanupWaypointPath();
-                        }
+                        this.cleanupWaypointPath();
                     }
                 }
                 if (processedOrder)
@@ -114,11 +102,7 @@ export class UnitOrderTrait implements NotifyTick, NotifyOwnerChange, NotifyTele
         }
         if (!orderCount && !hasTasks && this.waypointPath && this.currentWaypoint) {
             this.cleanupWaypoint(this.currentWaypoint, this.waypointPath);
-            if (this.waypointPath.loop) {
-                this.restartLoopPath();
-            } else {
-                this.cleanupWaypointPath();
-            }
+            this.cleanupWaypointPath();
         }
         let targetTask = currentTask;
         while (targetTask?.useChildTargetLines) {
@@ -183,9 +167,6 @@ export class UnitOrderTrait implements NotifyTick, NotifyOwnerChange, NotifyTele
     isIdle(): boolean {
         return this.orders.length === 0 && this.tasks.length === 0;
     }
-    getOrders(): Order[] {
-        return [...this.orders];
-    }
     getCurrentTask(): Task | undefined {
         return this.tasks[0];
     }
@@ -212,36 +193,6 @@ export class UnitOrderTrait implements NotifyTick, NotifyOwnerChange, NotifyTele
         this.tasks.length = 0;
         this.gameObject = undefined as any;
     }
-    private restartLoopPath(): void {
-        if (!this.waypointPath?.loop || !this.waypointPath.loopOrders || !this.waypointPath.loopWaypoints)
-            return;
-        const orders = this.waypointPath.loopOrders.get(this.gameObject);
-        if (!orders?.length) {
-            this.cleanupWaypointPath();
-            return;
-        }
-        const blueprints = this.waypointPath.loopWaypoints;
-        const newWaypoints: any[] = [];
-        for (const bp of blueprints) {
-            const wp = {
-                orderType: bp.orderType,
-                target: bp.target,
-                terminal: bp.terminal,
-                next: undefined,
-            };
-            if (newWaypoints.length) {
-                newWaypoints[newWaypoints.length - 1].next = wp;
-            }
-            newWaypoints.push(wp);
-        }
-        this.waypointPath.waypoints = newWaypoints;
-        this.currentWaypoint = undefined;
-        for (const order of orders) {
-            this.orders.push(order);
-            this.queuedOrders.add(order);
-        }
-    }
-
     private cleanupWaypointPath(): void {
         if (!this.waypointPath)
             return;

--- a/src/gui/screen/game/worldInteraction/PlanningMode.ts
+++ b/src/gui/screen/game/worldInteraction/PlanningMode.ts
@@ -98,7 +98,7 @@ export class PlanningMode {
             this.handleInvalidCommand(this.strings.get('MSG:NodeMaximum'));
             return;
         }
-        if (path.waypoints.slice(1).find((waypoint: any) => waypoint.target.equals(target))) {
+        if (path.waypoints.find((waypoint: any) => waypoint.target.equals(target))) {
             this.handleInvalidCommand(this.strings.get('MSG:PlanningModeInvalidNodeX'));
             return;
         }


### PR DESCRIPTION
修复：
光棱塔串联不应该有友军伤害，而是加强攻击力
工程师在执行占领任务时，再次命令工程师占领、停止或警戒，工程师就会停在原地无法移动
尤里心灵冲击波对载具不应有伤害 对狗应该有伤害
设置路径时，第4个路径点和初始路径点无法形成路径循环

https://github.com/user-attachments/assets/82f2447e-49d0-410e-9706-4e9502d5d33d


https://github.com/user-attachments/assets/879fdc49-e8b6-4c81-9e58-e6153d07867e


https://github.com/user-attachments/assets/4632d0f5-4602-4493-9b75-0dd86adabc89


https://github.com/user-attachments/assets/9e20fe8c-36a6-4b5c-a445-62fbdb40c171

