### PR TITLE
fix: 修复结算页面时间显示不正确的问题

### DIFF
--- a/src/gui/screen/mainMenu/score/ScoreTable.tsx
+++ b/src/gui/screen/mainMenu/score/ScoreTable.tsx
@@ -4,6 +4,7 @@ import { aiUiNames } from "@/game/gameopts/constants";
 import { CountryIcon } from "@/gui/component/CountryIcon";
 import { RankIndicator } from "@/gui/screen/mainMenu/lobby/component/RankIndicator";
 import { WolGameReportResult } from "@/network/WolGameReport";
+import { formatTimeDuration } from "@/util/format";
 interface ScoreTableProps {
     game: any;
     singlePlayer: boolean;
@@ -47,7 +48,11 @@ export const ScoreTable: React.FC<ScoreTableProps> = ({ game, singlePlayer, tour
             !singlePlayer &&
             (tournament || resultType === undefined) &&
             React.createElement("div", { className: "pending-results" }, strings.get("gui:gameresultwaiting")), localPlayerReport?.points &&
-            React.createElement("div", { className: "points-gain" }, (localPlayerReport.points > 0 ? "+" : "") + localPlayerReport.points)), React.createElement("div", { className: "score-table-wrapper" }, React.createElement("table", { className: "score-table" }, React.createElement("thead", null, React.createElement("tr", null, React.createElement("th", { className: "player-col" }, strings.get("GUI:Player")), React.createElement("th", { className: "country-col" }, strings.get("GUI:Country")), React.createElement("th", { className: "color-col" }, strings.get("GUI:Color")), React.createElement("th", { className: "score-col" }, strings.get("GUI:Score")), React.createElement("th", { className: "units-col" }, strings.get("GUI:Kills")), React.createElement("th", { className: "buildings-col" }, strings.get("GUI:Losses")), showReport && React.createElement("th", { className: "rank-col" }, "Rank"))), React.createElement("tbody", null, players.map((player: any) => {
+            React.createElement("div", { className: "points-gain" }, (localPlayerReport.points > 0 ? "+" : "") + localPlayerReport.points)),
+        React.createElement("div", { className: "score-header" },
+            React.createElement("span", null, strings.get("GUI:Map") + ": " + (game.gameOpts?.mapTitle ?? "")),
+            React.createElement("span", null, strings.get("GUI:Time") + ": " + formatTimeDuration(Math.floor(game.currentTime / 1000 / (game.speed?.value ?? 1))))),
+        React.createElement("div", { className: "score-table-wrapper" }, React.createElement("table", { className: "score-table" }, React.createElement("thead", null, React.createElement("tr", null, React.createElement("th", { className: "player-col" }, strings.get("GUI:Player")), React.createElement("th", { className: "country-col" }, strings.get("GUI:Country")), React.createElement("th", { className: "color-col" }, strings.get("GUI:Color")), React.createElement("th", { className: "score-col" }, strings.get("GUI:Score")), React.createElement("th", { className: "units-col" }, strings.get("GUI:Kills")), React.createElement("th", { className: "buildings-col" }, strings.get("GUI:Losses")), showReport && React.createElement("th", { className: "rank-col" }, "Rank"))), React.createElement("tbody", null, players.map((player: any) => {
         const isLocalPlayer = player === localPlayer;
         const playerReport = gameReport?.players.find((p: any) => p.name.toLowerCase() === player.name.toLowerCase());
         const rowColor = (typeof player.color === "string" ? player.color : player.color?.asHexString?.());

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -3,6 +3,6 @@ export function formatTimeDuration(seconds: number, showHours: boolean = false):
     const hours = Math.floor(seconds / 3600);
     seconds -= 3600 * hours;
     const minutes = Math.floor(seconds / 60);
-    seconds -= 60 * minutes;
+    seconds = Math.floor(seconds - 60 * minutes);
     return [...(hours || !showHours ? [hours] : []), pad(minutes, "00"), pad(seconds, "00")].join(":");
 }


### PR DESCRIPTION
## 问题

游戏结束后结算页面显示的时间是游戏逻辑时间（受游戏速度缩放），而非真实墙钟时间。默认速度 6 对应 4 倍速，导致实际游戏时间二三十分钟，被展示成了一个半小时

<img width="1788" height="1324" alt="image" src="https://github.com/user-attachments/assets/3d63319d-fd09-40cf-a76b-23455468ebd8" />

## 原因

`game.currentTime` 每 tick 固定累加 `1000 / BASE_TICKS_PER_SECOND`(66.67ms)，不考虑实际游戏速度。在 4 倍速下，每真实秒产生 60 个 tick，`currentTime` 增长 4000ms，导致显示时间是真实时间的 4 倍。

## 修复

- **时间换算**：`game.currentTime / 1000 / game.speed.value`，将游戏逻辑时间除以速度倍数还原为真实时间
- **补上 score-header**：结算页面缺少地图名和时间的显示（CSS `.score-header` 已存在但无对应代码）
- **修复 `formatTimeDuration` 浮点数精度问题**：`seconds` 减法后可能产生小数，导致输出 `"33.333"` 而非 `"33"`

## 改动文件

- `src/gui/screen/mainMenu/score/ScoreTable.tsx` — 新增 score-header，显示地图名和真实时长
- `src/util/format.ts` — `Math.floor` 修复浮点数