### PR TITLE
fix：修复Bot沙箱类型剥离正则误匹配三元表达式的问题

### DIFF
--- a/src/LocalPrefs.ts
+++ b/src/LocalPrefs.ts
@@ -20,7 +20,8 @@ export enum StorageKey {
     PreferredServerRegion = "_r_region",
     TauntsEnabled = "_r_taunts",
     LanPlayerName = "_r_lanPlayerName",
-    LanRecentPlays = "_r_lanRecentPlays"
+    LanRecentPlays = "_r_lanRecentPlays",
+    UploadedBots = "_r_uploadedBots"
 }
 export class LocalPrefs {
     protected storage: Storage;

--- a/src/game/GameFactory.ts
+++ b/src/game/GameFactory.ts
@@ -142,6 +142,7 @@ export class GameFactory {
             let playerName: string;
             let isAi: boolean;
             let aiDifficulty: string | undefined;
+            let customBotId: string | undefined;
             if (isHumanPlayerInfo(playerInfo)) {
                 playerName = playerInfo.name;
                 isAi = false;
@@ -150,6 +151,7 @@ export class GameFactory {
                 playerName = game.getAiPlayerName(playerInfo);
                 isAi = true;
                 aiDifficulty = (playerInfo as any).difficulty;
+                customBotId = (playerInfo as any).customBotId;
             }
             if (playerInfo.countryId === (OBS_COUNTRY_ID as any)) {
                 game.addPlayer(playerFactory.createObserver(playerName, rules));
@@ -162,7 +164,7 @@ export class GameFactory {
             const countryName: string = multiplayerCountries[parseInt(resolvedCountryId)].name;
             const country: Country = Country.factory(countryName, rules as any);
             const color: string = multiplayerColors[parseInt(resolvedColorId)];
-            const player = playerFactory.createCombatant(playerName, country, resolvedStartPos, color, isAi, aiDifficulty);
+            const player = playerFactory.createCombatant(playerName, country, resolvedStartPos, color, isAi, aiDifficulty, customBotId);
             game.addPlayer(player);
         });
     }

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -36,6 +36,7 @@ export class Player {
     public readonly isObserver: boolean;
     public readonly isNeutral: boolean;
     public aiDifficulty?: any;
+    public customBotId?: string;
     public powerTrait?: any;
     public radarTrait?: any;
     public superWeaponsTrait?: any;

--- a/src/game/ai/thirdpartbot/BotRegistry.ts
+++ b/src/game/ai/thirdpartbot/BotRegistry.ts
@@ -1,4 +1,15 @@
 import { ThirdPartyBotMeta } from './ThirdPartyBotInterface';
+import { BotSandbox } from './BotSandbox';
+
+interface PersistedBot {
+    id: string;
+    displayName: string;
+    version: string;
+    author: string;
+    description?: string;
+    source: string;
+    sourceFile: string;
+}
 
 /**
  * Registry for third-party bots.
@@ -7,6 +18,7 @@ import { ThirdPartyBotMeta } from './ThirdPartyBotInterface';
 export class BotRegistry {
     private static instance: BotRegistry;
     private bots: Map<string, ThirdPartyBotMeta> = new Map();
+    private botSources: Map<string, { source: string; sourceFile: string }> = new Map();
 
     private constructor() {}
 
@@ -29,6 +41,14 @@ export class BotRegistry {
     }
 
     /**
+     * Register a bot and store its source for persistence.
+     */
+    registerWithSource(meta: ThirdPartyBotMeta, source: string, sourceFile: string): void {
+        this.register(meta);
+        this.botSources.set(meta.id, { source, sourceFile });
+    }
+
+    /**
      * Unregister a third-party bot by ID.
      */
     unregister(botId: string): boolean {
@@ -37,6 +57,7 @@ export class BotRegistry {
             console.warn(`[BotRegistry] Cannot unregister built-in bot "${botId}".`);
             return false;
         }
+        this.botSources.delete(botId);
         return this.bots.delete(botId);
     }
 
@@ -73,5 +94,47 @@ export class BotRegistry {
      */
     get size(): number {
         return this.bots.size;
+    }
+
+    /**
+     * Serialize uploaded bots for localStorage persistence.
+     */
+    serializeUploadedBots(): string {
+        const bots: PersistedBot[] = [];
+        for (const meta of this.getUploadedBots()) {
+            const sourceInfo = this.botSources.get(meta.id);
+            if (sourceInfo) {
+                bots.push({
+                    id: meta.id,
+                    displayName: meta.displayName,
+                    version: meta.version,
+                    author: meta.author,
+                    description: meta.description,
+                    source: sourceInfo.source,
+                    sourceFile: sourceInfo.sourceFile,
+                });
+            }
+        }
+        return JSON.stringify(bots);
+    }
+
+    /**
+     * Load persisted bots from serialized data.
+     */
+    loadPersistedBots(data: string): void {
+        try {
+            const bots: PersistedBot[] = JSON.parse(data);
+            for (const bot of bots) {
+                if (this.bots.has(bot.id)) {
+                    continue;
+                }
+                const meta = BotSandbox.loadBotFromSource(bot.source, bot.sourceFile);
+                if (meta) {
+                    this.botSources.set(meta.id, { source: bot.source, sourceFile: bot.sourceFile });
+                }
+            }
+        } catch (e) {
+            console.error('[BotRegistry] Failed to load persisted bots:', e);
+        }
     }
 }

--- a/src/game/ai/thirdpartbot/BotSandbox.ts
+++ b/src/game/ai/thirdpartbot/BotSandbox.ts
@@ -102,8 +102,18 @@ export class BotSandbox {
         // 5. Generic type parameters on function declarations: `function foo<T>(`
         source = source.replace(/(\bfunction\s+\w+)\s*<[^>]*>/g, '$1');
 
-        // 6. Return type annotations: `): ReturnType {` or `): ReturnType;`
-        source = source.replace(/\)\s*:\s*[\w<>[\]|&., ]+(?=\s*[{;])/g, ')');
+        // 6. Return type annotations on function declarations/expressions:
+        //    `function foo(params): ReturnType {`
+        //    Anchored to `function` keyword to avoid false-matching ternary `) : expr`.
+        source = source.replace(
+            /(\bfunction\s*\w*\s*\([^)]*\))\s*:\s*[\w<>[\]|&., ]+(?=\s*\{)/g,
+            '$1',
+        );
+        // Arrow function return types: `(params): ReturnType =>`
+        source = source.replace(
+            /(\([^)]*\))\s*:\s*[\w<>[\]|&., ]+(?=\s*=>)/g,
+            '$1',
+        );
 
         // 7. Strip type annotations from function/method parameter lists only.
         //    Each parameter is split by comma and handled individually so that
@@ -344,8 +354,8 @@ export class BotSandbox {
                 sourceFile: sourceFileName,
             };
 
-            // Register the bot
-            BotRegistry.getInstance().register(meta);
+            // Register the bot with source for persistence
+            BotRegistry.getInstance().registerWithSource(meta, mainScript, sourceFileName);
             return meta;
         } catch (e) {
             console.error('[BotSandbox] Failed to load bot:', e);

--- a/src/game/bot/BotFactory.ts
+++ b/src/game/bot/BotFactory.ts
@@ -16,6 +16,7 @@ export class BotFactory {
         country: {
             name: string;
         };
+        customBotId?: string;
     }): Bot {
         if (!player.isAi) {
             throw new Error(`Player "${player.name}" is not an AI`);
@@ -23,6 +24,14 @@ export class BotFactory {
 
         if (player.aiDifficulty === AiDifficulty.Custom) {
             const registry = BotRegistry.getInstance();
+            if (player.customBotId) {
+                const meta = registry.get(player.customBotId);
+                if (meta) {
+                    console.info(`[BotFactory] Using bot "${meta.displayName}" for "${player.name}"`);
+                    return new ThirdPartyBotAdapter(player.name, player.country.name, meta);
+                }
+                console.warn(`[BotFactory] Custom bot "${player.customBotId}" not found, trying fallback`);
+            }
             const uploadedBots = registry.getUploadedBots();
             if (uploadedBots.length > 0) {
                 const meta = uploadedBots[0];

--- a/src/game/gameopts/GameOpts.ts
+++ b/src/game/gameopts/GameOpts.ts
@@ -18,6 +18,7 @@ export interface HumanPlayerInfo {
 }
 export interface AiPlayerInfo {
     difficulty: AiDifficulty;
+    customBotId?: string;
     countryId: number;
     colorId: number;
     startPos: number;

--- a/src/game/player/PlayerFactory.ts
+++ b/src/game/player/PlayerFactory.ts
@@ -15,10 +15,11 @@ export class PlayerFactory {
         this.gameOpts = gameOpts;
         this.allAvailableObjects = allAvailableObjects;
     }
-    createCombatant(id: any, country: any, team: any, color: any, isAi: boolean, aiDifficulty: any): Player {
+    createCombatant(id: any, country: any, team: any, color: any, isAi: boolean, aiDifficulty: any, customBotId?: string): Player {
         let player = new Player(id, country, team, color);
         player.isAi = isAi;
         player.aiDifficulty = aiDifficulty;
+        player.customBotId = customBotId;
         player.powerTrait = new PowerTrait(player);
         player.traits.add(player.powerTrait);
         player.radarTrait = new RadarTrait();

--- a/src/gui/screen/mainMenu/lobby/PregameController.ts
+++ b/src/gui/screen/mainMenu/lobby/PregameController.ts
@@ -23,6 +23,7 @@ import { findIndexReverse } from '@/util/array';
 import { PreferredHostOpts } from '@/gui/screen/mainMenu/lobby/PreferredHostOpts';
 import { Parser } from '@/network/gameopt/Parser';
 import { Serializer } from '@/network/gameopt/Serializer';
+import { BotRegistry } from '@/game/ai/thirdpartbot/BotRegistry';
 
 interface Rules {
     getMultiplayerCountries(): any[];
@@ -93,6 +94,7 @@ function cloneAiPlayer(ai: any) {
     return ai
         ? {
             difficulty: ai.difficulty,
+            customBotId: ai.customBotId,
             countryId: ai.countryId,
             colorId: ai.colorId,
             startPos: ai.startPos,
@@ -143,6 +145,7 @@ function cloneSlotsInfo(slotsInfo: SlotInfo[]): SlotInfo[] {
         type: slot.type,
         name: slot.name,
         difficulty: slot.difficulty,
+        customBotId: slot.customBotId,
     }));
 }
 
@@ -301,6 +304,21 @@ export class PregameController {
         this.saveBotSettings();
     }
 
+    private buildAvailableAiNames(): Map<string, string> {
+        const names = new Map<string, string>();
+        names.set('Easy', aiUiNames.get(AiDifficulty.Easy)!);
+        names.set('Normal', aiUiNames.get(AiDifficulty.Normal)!);
+        const uploadedBots = BotRegistry.getInstance().getUploadedBots();
+        if (uploadedBots.length > 0) {
+            for (const bot of uploadedBots) {
+                names.set(`Custom:${bot.id}`, bot.displayName);
+            }
+        } else {
+            names.set('Custom', aiUiNames.get(AiDifficulty.Custom)!);
+        }
+        return names;
+    }
+
     createLobbyFormProps(options: PregameLobbyFormOptions): any {
         const gameOpts = this.requireGameOpts();
         const slotsInfo = this.requireSlotsInfo();
@@ -324,7 +342,7 @@ export class PregameController {
             ]),
             availablePlayerCountries: [RANDOM_COUNTRY_NAME, OBS_COUNTRY_NAME].concat(this.getAvailablePlayerCountries()),
             availablePlayerColors: this.getSelectablePlayerColors(playerSlots),
-            availableAiNames: new Map([...aiUiNames.entries()]),
+            availableAiNames: this.buildAvailableAiNames(),
             availableStartPositions: this.getSelectableStartPositions(playerSlots, gameOpts.maxSlots),
             maxTeams: 4,
             lobbyType: options.lobbyType,
@@ -369,8 +387,8 @@ export class PregameController {
                 this.handleTeamSelect(team, slotIndex);
                 onStateChange();
             },
-            onSlotChange: (occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty) => {
-                this.handleSlotChange(occupation, slotIndex, aiDifficulty);
+            onSlotChange: (occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty, customBotId?: string) => {
+                this.handleSlotChange(occupation, slotIndex, aiDifficulty, customBotId);
                 onStateChange();
             },
             onToggleShortGame: (value: boolean) => {
@@ -511,7 +529,7 @@ export class PregameController {
             preferredOpts.applyMpDialogSettings(mpDialogSettings);
         }
 
-        const lastBots = savedBots ? new Parser().parseAiOpts(savedBots) : undefined;
+        const lastBots = savedBots ? this.parseSavedBots(savedBots) : undefined;
         const defaultAiDifficulty = AiDifficulty.Easy;
         const humanCountryId = savedCountry !== undefined &&
             Number(savedCountry) < this.getAvailablePlayerCountries().length
@@ -561,6 +579,7 @@ export class PregameController {
                     if (difficulty !== undefined) {
                         return {
                             difficulty,
+                            customBotId: lastBots?.[index]?.customBotId,
                             countryId: lastBots?.[index]?.countryId ?? RANDOM_COUNTRY_ID,
                             colorId: lastBots?.[index]?.colorId ?? RANDOM_COLOR_ID,
                             startPos: lastBots?.[index]?.startPos ?? RANDOM_START_POS,
@@ -581,7 +600,8 @@ export class PregameController {
         this.slotsInfo = [{ type: NetSlotType.Player, name: this.playerName }];
         for (let index = 1; index < 8; index += 1) {
             if (index < effectiveMaxSlots && this.gameOpts.aiPlayers[index]) {
-                this.slotsInfo.push({ type: NetSlotType.Ai, difficulty: (this.gameOpts.aiPlayers[index] as any).difficulty });
+                const ai = this.gameOpts.aiPlayers[index]!;
+                this.slotsInfo.push({ type: NetSlotType.Ai, difficulty: ai.difficulty, customBotId: ai.customBotId });
             }
             else {
                 const type = index < effectiveMaxSlots
@@ -717,12 +737,12 @@ export class PregameController {
         this.updatePlayerInfo(this.getCountryIdByName(playerSlots[slotIndex].country), this.getColorIdByName(playerSlots[slotIndex].color), playerSlots[slotIndex].startPos, teamId, slotIndex);
     }
 
-    private handleSlotChange(occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty): void {
-        this.changeSlotType(occupation, slotIndex, aiDifficulty);
+    private handleSlotChange(occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty, customBotId?: string): void {
+        this.changeSlotType(occupation, slotIndex, aiDifficulty, customBotId);
         this.saveBotSettings();
     }
 
-    private changeSlotType(occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty): void {
+    private changeSlotType(occupation: SlotOccupation, slotIndex: number, aiDifficulty?: AiDifficulty, customBotId?: string): void {
         if (slotIndex === 0) {
             throw new Error('Change slot type of host');
         }
@@ -734,9 +754,11 @@ export class PregameController {
             const slot = slotsInfo[slotIndex];
             slot.type = NetSlotType.Ai;
             slot.difficulty = aiDifficulty;
+            slot.customBotId = customBotId;
             if (!gameOpts.aiPlayers[slotIndex]) {
                 gameOpts.aiPlayers[slotIndex] = {
                     difficulty: aiDifficulty,
+                    customBotId,
                     countryId: RANDOM_COUNTRY_ID,
                     colorId: RANDOM_COLOR_ID,
                     startPos: RANDOM_START_POS,
@@ -744,6 +766,7 @@ export class PregameController {
                 } as any;
             }
             gameOpts.aiPlayers[slotIndex]!.difficulty = aiDifficulty;
+            gameOpts.aiPlayers[slotIndex]!.customBotId = customBotId;
             return;
         }
 
@@ -847,6 +870,7 @@ export class PregameController {
 
             if (slot.type === NetSlotType.Ai) {
                 playerSlot.aiDifficulty = slot.difficulty;
+                playerSlot.customBotId = slot.customBotId;
                 playerSlot.type = UiSlotType.Ai;
             }
             else if (slot.type === NetSlotType.Player) {
@@ -915,7 +939,32 @@ export class PregameController {
     }
 
     private saveBotSettings(): void {
-        this.localPrefs.setItem(StorageKey.LastBots, new Serializer().serializeAiOpts(this.requireGameOpts().aiPlayers));
+        const aiPlayers = this.requireGameOpts().aiPlayers;
+        const hasCustomBotId = aiPlayers.some(ai => ai?.customBotId);
+        if (hasCustomBotId) {
+            this.localPrefs.setItem(StorageKey.LastBots, JSON.stringify(
+                aiPlayers.map(ai => ai
+                    ? { d: ai.difficulty, b: ai.customBotId, c: ai.countryId, co: ai.colorId, s: ai.startPos, t: ai.teamId }
+                    : null
+                )
+            ));
+        } else {
+            this.localPrefs.setItem(StorageKey.LastBots, new Serializer().serializeAiOpts(aiPlayers));
+        }
+    }
+
+    private parseSavedBots(data: string): (any | undefined)[] {
+        if (data.startsWith('[')) {
+            try {
+                const parsed = JSON.parse(data);
+                return parsed.map((item: any) =>
+                    item ? { difficulty: item.d, customBotId: item.b, countryId: item.c, colorId: item.co, startPos: item.s, teamId: item.t } : undefined
+                );
+            } catch {
+                return new Parser().parseAiOpts(data);
+            }
+        }
+        return new Parser().parseAiOpts(data);
     }
 
     private savePreferences(): void {

--- a/src/gui/screen/mainMenu/lobby/SkirmishScreen.ts
+++ b/src/gui/screen/mainMenu/lobby/SkirmishScreen.ts
@@ -13,6 +13,7 @@ import { MusicType } from '@/engine/sound/Music';
 import { OBS_COUNTRY_ID } from '@/game/gameopts/constants';
 import { MapFile } from '@/data/MapFile';
 import { PregameController, PregameMapSelectionResult } from '@/gui/screen/mainMenu/lobby/PregameController';
+import { BotRegistry } from '@/game/ai/thirdpartbot/BotRegistry';
 
 interface GameMode {
     id: number;
@@ -97,6 +98,7 @@ export class SkirmishScreen extends MainMenuScreen {
     onEnter(): void {
         this.controller.toggleMainVideo(false);
         this.lobbyForm = undefined;
+        this.loadPersistedBots();
         this.pregameController = new PregameController(
             this.strings,
             this.rules,
@@ -121,8 +123,7 @@ export class SkirmishScreen extends MainMenuScreen {
             this.pregameController?.applyMapSelection(params);
         }
         this.updateMapPreview();
-        this.refreshSidebarMpText();
-        this.refreshLobbyForm();
+        this.initView();
     }
 
     async onLeave(): Promise<void> {
@@ -137,8 +138,13 @@ export class SkirmishScreen extends MainMenuScreen {
     }
 
     private async createGame(): Promise<void> {
+        const controller = this.pregameController;
+        if (!controller) {
+            return;
+        }
+
         try {
-            await this.pregameController?.initialize();
+            await controller.initialize();
         }
         catch (error) {
             this.handleError(
@@ -147,6 +153,11 @@ export class SkirmishScreen extends MainMenuScreen {
                     ? this.strings.get('TXT_DOWNLOAD_FAILED')
                     : this.strings.get('WOL:MatchErrorCreatingGame')
             );
+            return;
+        }
+
+        // Bail out if the screen was left or re-entered during initialization
+        if (this.pregameController !== controller) {
             return;
         }
 
@@ -382,7 +393,9 @@ export class SkirmishScreen extends MainMenuScreen {
 
                 if (result.success && result.meta && messageDiv) {
                     messageDiv.innerHTML = `<div class="bot-upload-message bot-upload-message-success">${this.strings.get('GUI:BotUpload:Success') || 'Bot uploaded successfully!'}</div>`;
+                    this.persistBots();
                     this.refreshBotList();
+                    this.refreshLobbyForm();
                 }
                 else if (messageDiv) {
                     messageDiv.innerHTML = `<div class="bot-upload-message bot-upload-message-error">${(result.errors || ['Upload failed']).join('\n')}</div>`;
@@ -429,11 +442,24 @@ export class SkirmishScreen extends MainMenuScreen {
                     const botId = (button as HTMLElement).dataset.botId;
                     if (botId) {
                         BotRegistry.getInstance().unregister(botId);
+                        this.persistBots();
                         this.refreshBotList();
+                        this.refreshLobbyForm();
                     }
                 });
             });
         });
+    }
+
+    private loadPersistedBots(): void {
+        const data = this.localPrefs.getItem(StorageKey.UploadedBots);
+        if (data) {
+            BotRegistry.getInstance().loadPersistedBots(data);
+        }
+    }
+
+    private persistBots(): void {
+        this.localPrefs.setItem(StorageKey.UploadedBots, BotRegistry.getInstance().serializeUploadedBots());
     }
 
     private async unrender(): Promise<void> {

--- a/src/gui/screen/mainMenu/lobby/component/LobbyForm.tsx
+++ b/src/gui/screen/mainMenu/lobby/component/LobbyForm.tsx
@@ -48,7 +48,7 @@ interface LobbyFormProps {
     teamsRequired: boolean;
     maxTeams: number;
     availableAiNames: any;
-    onSlotChange: (occupation: number, slotIndex: number, aiDifficulty?: any) => void;
+    onSlotChange: (occupation: number, slotIndex: number, aiDifficulty?: any, customBotId?: string) => void;
     onToggleShortGame: (checked: boolean) => void;
     onToggleMcvRepacks: (checked: boolean) => void;
     onToggleCratesAppear: (checked: boolean) => void;
@@ -72,23 +72,38 @@ export class LobbyForm extends React.Component<LobbyFormProps> {
     private getFirstAvailableAiDifficulty(): AiDifficulty {
         const iterator = this.props.availableAiNames.keys();
         const first = iterator.next();
-        return first.done ? AiDifficulty.Easy : first.value;
+        if (first.done) return AiDifficulty.Easy;
+        const key = first.value as string;
+        if (key.startsWith('Custom:')) return AiDifficulty.Custom;
+        return AiDifficulty[key as keyof typeof AiDifficulty] ?? AiDifficulty.Easy;
     }
     onPlayerSelect = (value: string, slotIndex: number) => {
         let occupation: number;
         let aiDifficulty: any;
+        let customBotId: string | undefined;
         if (value.match(/^\d+$/)) {
             occupation = Number(value);
         }
         else {
             occupation = SlotOccupation.Occupied;
-            aiDifficulty = AiDifficulty[value as keyof typeof AiDifficulty];
-            if (aiDifficulty === undefined ||
-                !this.props.availableAiNames.has(aiDifficulty)) {
-                aiDifficulty = this.getFirstAvailableAiDifficulty();
+            if (value.startsWith('Custom:')) {
+                aiDifficulty = AiDifficulty.Custom;
+                customBotId = value.slice('Custom:'.length);
+            } else {
+                aiDifficulty = AiDifficulty[value as keyof typeof AiDifficulty];
+                if (aiDifficulty === undefined ||
+                    !this.props.availableAiNames.has(value)) {
+                    const firstKey = this.props.availableAiNames.keys().next().value;
+                    if (firstKey?.startsWith('Custom:')) {
+                        aiDifficulty = AiDifficulty.Custom;
+                        customBotId = firstKey.slice('Custom:'.length);
+                    } else {
+                        aiDifficulty = this.getFirstAvailableAiDifficulty();
+                    }
+                }
             }
         }
-        this.props.onSlotChange(occupation, slotIndex, aiDifficulty);
+        this.props.onSlotChange(occupation, slotIndex, aiDifficulty, customBotId);
     };
     render() {
         const { strings, lobbyType, mpDialogSettings } = this.props;
@@ -277,14 +292,19 @@ export class LobbyForm extends React.Component<LobbyFormProps> {
         if (displayOccupation === SlotOccupation.Occupied &&
             slot.type === SlotType.Ai) {
             optionsMap.delete(SlotOccupation.Occupied);
-            const selectedDifficulty = this.props.availableAiNames.has(slot.aiDifficulty)
-                ? slot.aiDifficulty
-                : this.getFirstAvailableAiDifficulty();
-            selectedValue = AiDifficulty[selectedDifficulty];
+            if (slot.customBotId && this.props.availableAiNames.has(`Custom:${slot.customBotId}`)) {
+                selectedValue = `Custom:${slot.customBotId}`;
+            } else {
+                const diffKey = AiDifficulty[slot.aiDifficulty];
+                selectedValue = this.props.availableAiNames.has(diffKey)
+                    ? diffKey
+                    : [...this.props.availableAiNames.keys()][0] ?? 'Easy';
+            }
         }
         if (slot.type !== SlotType.Observer) {
-            this.props.availableAiNames.forEach((name: string, difficulty: number) => {
-                optionsMap.set(AiDifficulty[difficulty], strings.get(name));
+            this.props.availableAiNames.forEach((name: string, key: string) => {
+                const resolvedName = key.startsWith('Custom:') ? name : strings.get(name);
+                optionsMap.set(key, resolvedName);
             });
         }
         return (<Select initialValue={"" + selectedValue} disabled={!isHost} onSelect={(value) => this.onPlayerSelect(value, index)} className="player-name" tooltip={isSingleplayer
@@ -300,6 +320,9 @@ export class LobbyForm extends React.Component<LobbyFormProps> {
                             let tooltipKey: string | undefined;
                             if (value === SlotOccupation.Closed) {
                                 tooltipKey = "STT:PlayerNone";
+                            }
+                            else if (typeof value === 'string' && value.startsWith('Custom:')) {
+                                tooltipKey = undefined;
                             }
                             else {
                                 tooltipKey = aiUiTooltips.get(AiDifficulty[value as keyof typeof AiDifficulty] as AiDifficulty);

--- a/src/network/gameopt/SlotInfo.ts
+++ b/src/network/gameopt/SlotInfo.ts
@@ -9,6 +9,7 @@ export interface SlotInfo {
     type: SlotType;
     name?: string;
     difficulty?: number;
+    customBotId?: string;
 }
 export interface PingInfo {
     playerName: string;


### PR DESCRIPTION
BotSandbox.stripTypes() 中的返回类型注解正则 /\)\s*:\s*[...]+(?=\s*[{;])/ 会 错误地将三元表达式 fn() : { ... } 中的冒号识别为类型注解，导致代码被破坏，
上传的Bot无法加载（报 SyntaxError）。

修复方案：将返回类型正则锚定到 function 关键字和箭头函数签名，避免误匹配
普通的三元运算符表达式。

同时包含：Bot注册持久化、大厅界面及玩家工厂等相关改动。
<img width="835" height="641" alt="截屏2026-04-13 10 39 52" src="https://github.com/user-attachments/assets/eb842f32-65e2-4fb1-b6ac-076e9d4b7084" />
