### PR TITLE
新增场景沙盒 + 修复桥梁通行（陆/海/坦克）

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -43,6 +43,7 @@ const optionalDevModuleImporters: Record<string, () => Promise<any>> = {
     './tools/UnitMovementTester': () => import('./tools/UnitMovementTester'),
     './tools/PerformanceTester': () => import('./tools/PerformanceTester'),
     './tools/LiveInteractionTester': () => import('./tools/LiveInteractionTester'),
+    './tools/SceneSandboxTester': () => import('./tools/SceneSandboxTester'),
 };
 
 export type SplashScreenUpdateCallback = (props: ComponentProps<typeof SplashScreenComponent> | null) => void;
@@ -902,6 +903,34 @@ export class Application {
             const { PerformanceTester } = await this.importOptionalDevModule('./tools/PerformanceTester');
             await PerformanceTester.main(this.rootEl!, this.strings, this.runtimeVars, this.generalOptions, this.createTestToolContext());
             currentHandler = PerformanceTester;
+        });
+        this.routing.addRoute("/scenesandbox", async () => {
+            if (!Engine.vfs) {
+                throw new Error("Original game files must be provided.");
+            }
+            console.log('[Application] Initializing SceneSandboxTester');
+            const { TestToolSupport } = await this.importOptionalDevModule('./tools/TestToolSupport');
+            const mapCandidates = ["mp18s3.map", "mp03t4.map"];
+            let loadedMap: any;
+            let loadedMapName = "";
+            for (const mapName of mapCandidates) {
+                try {
+                    loadedMap = await TestToolSupport.loadMap(this.createTestToolContext().mapResourceLoader!, mapName);
+                    loadedMapName = mapName;
+                    break;
+                }
+                catch (error) {
+                    console.warn(`[Application] Failed to load sandbox map "${mapName}"`, error);
+                }
+            }
+            if (!loadedMap) {
+                throw new Error("Failed to load a scene sandbox map.");
+            }
+            const { SceneSandboxTester } = await this.importOptionalDevModule('./tools/SceneSandboxTester');
+            await SceneSandboxTester.main(Engine.vfs, loadedMap, this.rootEl!, this.strings, this.createTestToolContext(), {
+                mapName: loadedMapName,
+            });
+            currentHandler = SceneSandboxTester;
         });
         this.routing.addRoute("/liveinteraction", async () => {
             if (!Engine.vfs) {

--- a/src/engine/renderable/entity/Infantry.ts
+++ b/src/engine/renderable/entity/Infantry.ts
@@ -53,6 +53,7 @@ export class Infantry {
     private extraLight: THREE.Vector3;
     private target: THREE.Object3D;
     private posWrap: THREE.Object3D;
+    private mainObject: THREE.Object3D;
     private shpRenderable: ShpRenderable;
     private placeholder: DebugRenderable;
     private blobShadow: BlobShadow;
@@ -78,6 +79,7 @@ export class Infantry {
     private lastFiring: boolean;
     private lastPanicked: boolean;
     private lastStance: StanceType;
+    private lastBridgeRenderOrder?: number;
     constructor(gameObject: any, rules: any, art: any, imageFinder: any, theater: any, palette: any, camera: any, lighting: any, debugFrame: any, gameSpeed: any, selectionModel: any, useSpriteBatching: boolean, useMeshInstancing: boolean, pipOverlay: any, worldSound: any) {
         this.gameObject = gameObject;
         this.rules = rules;
@@ -136,6 +138,7 @@ export class Infantry {
             this.withPosition.matrixUpdate = true;
             this.withPosition.applyTo(this);
             this.createObjects(obj);
+            this.updateBridgeRenderOrder();
             this.shpRenderable?.setExtraLight(this.extraLight);
             if (this.pipOverlay) {
                 this.pipOverlay.create3DObject();
@@ -164,6 +167,7 @@ export class Infantry {
         this.plugins.forEach((plugin) => plugin.update(deltaTime));
         const { zone, stance, isCrashing, isMoving, isFiring, isPanicked, owner, veteranLevel, } = this.gameObject;
         this.pipOverlay?.update(deltaTime);
+        this.updateBridgeRenderOrder();
         this.blobShadow?.update(deltaTime, undefined as any);
         if (veteranLevel !== this.lastVeteranLevel) {
             if (veteranLevel === VeteranLevel.Elite && this.lastVeteranLevel !== undefined) {
@@ -464,7 +468,7 @@ export class Infantry {
         const posWrap = this.posWrap = new THREE.Object3D();
         posWrap.matrixAutoUpdate = false;
         parent.add(posWrap);
-        const mainObject = this.createMainObject(this.objectArt);
+        const mainObject = this.mainObject = this.createMainObject(this.objectArt);
         posWrap.add(mainObject);
         if ((this.gameObject.rules.movementZone !== MovementZone.Fly || this.objectArt.isVoxel) &&
             this.gameObject.stance !== StanceType.Paradrop) {
@@ -472,6 +476,16 @@ export class Infantry {
             this.blobShadow.create3DObject();
             this.posWrap.add(this.blobShadow.get3DObject());
         }
+    }
+    private updateBridgeRenderOrder(): void {
+        const renderOrder = this.gameObject.onBridge ? 2 : 0;
+        if (this.lastBridgeRenderOrder === renderOrder) {
+            return;
+        }
+        this.lastBridgeRenderOrder = renderOrder;
+        this.mainObject?.traverse((object) => {
+            object.renderOrder = renderOrder;
+        });
     }
     createMainObject(art: any): THREE.Object3D {
         let image;
@@ -522,7 +536,10 @@ export class Infantry {
             this.posWrap.remove(currentObject);
             (this.shpRenderable ?? this.placeholder)?.dispose();
         }
-        this.posWrap.add(this.createMainObject(art));
+        this.mainObject = this.createMainObject(art);
+        this.posWrap.add(this.mainObject);
+        this.lastBridgeRenderOrder = undefined;
+        this.updateBridgeRenderOrder();
     }
     onCreate(renderableManager: any): void {
         this.renderableManager = renderableManager;

--- a/src/engine/renderable/entity/Overlay.ts
+++ b/src/engine/renderable/entity/Overlay.ts
@@ -266,20 +266,19 @@ export class Overlay {
                     EngineMathUtils.translateTowardsCamera(shadowMesh, this.camera as any, (MAGIC_OFFSET + 0.05) * Coords.ISO_WORLD_SCALE);
                     shadowMesh.updateMatrix();
                 }
-                const bridgeShadowSurface = this.createBridgeShadowSurface();
-                parent.add(bridgeShadowSurface);
             }
             if (this.gameObject.isBridge()) {
+                const renderOrder = this.gameObject.isHighBridge() ? 1 : -1;
                 const shapeMesh = mainRenderable.getShapeMesh();
                 if (shapeMesh) {
-                    (shapeMesh as THREE.Mesh).renderOrder = -1;
+                    (shapeMesh as THREE.Mesh).renderOrder = renderOrder;
                     const mat = (shapeMesh as THREE.Mesh).material as THREE.Material;
                     mat.depthTest = false;
                     mat.depthWrite = false;
                 }
                 const shadowMesh = mainRenderable.getShadowMesh();
                 if (shadowMesh) {
-                    (shadowMesh as THREE.Mesh).renderOrder = -1;
+                    (shadowMesh as THREE.Mesh).renderOrder = renderOrder;
                     const smat = (shadowMesh as THREE.Mesh).material as THREE.Material;
                     smat.depthTest = false;
                     smat.depthWrite = false;
@@ -338,7 +337,8 @@ export class Overlay {
     private createMainObject(imageSource: any, drawOffset: THREE.Vector3): ShpRenderable {
         const isWall = this.objectRules.wall;
         const heightOffset = this.gameObject.isHighBridge() ? 4 : 0;
-        const renderable = ShpRenderable.factory(imageSource, this.palette, this.camera, drawOffset, this.objectArt.hasShadow && !this.gameObject.isLowBridge(), heightOffset, isWall);
+        const hasShadow = this.objectArt.hasShadow && !this.gameObject.isLowBridge() && !this.gameObject.isHighBridge();
+        const renderable = ShpRenderable.factory(imageSource, this.palette, this.camera, drawOffset, hasShadow, heightOffset, isWall);
         renderable.setBatched(this.useSpriteBatching);
         if (this.useSpriteBatching) {
             renderable.setBatchPalettes([this.palette]);

--- a/src/engine/renderable/entity/Vehicle.ts
+++ b/src/engine/renderable/entity/Vehicle.ts
@@ -75,6 +75,7 @@ interface GameObjectInterface {
     };
     tile: any;
     tileElevation: number;
+    onBridge: boolean;
     direction: number;
     spinVelocity: number;
     zone: any;
@@ -203,6 +204,7 @@ export class Vehicle {
     lastTurretFacing?: number;
     lastMoving?: boolean;
     lastFiring?: boolean;
+    lastBridgeRenderOrder?: number;
     destroyStartTime?: number;
     sinkWakeAnims: any[] = [];
     squidGrabAnim?: any;
@@ -275,6 +277,7 @@ export class Vehicle {
                 (this.withPosition.matrixUpdate = !0),
                 this.withPosition.applyTo(this),
                 this.createObjects(e),
+                this.updateBridgeRenderOrder(),
                 this.vxlBuilders.forEach((e) => e.setExtraLight(this.vxlExtraLight)),
                 this.shpRenderable?.setExtraLight(this.shpExtraLight),
                 this.pipOverlay &&
@@ -311,6 +314,7 @@ export class Vehicle {
     update(i, r = 0) {
         this.plugins.forEach((e) => e.update(i)),
             this.pipOverlay?.update(i),
+            this.updateBridgeRenderOrder(),
             this.gameObject.veteranLevel !== this.lastVeteranLevel &&
                 (this.gameObject.veteranLevel === O.VeteranLevel.Elite &&
                     void 0 !== this.lastVeteranLevel &&
@@ -660,6 +664,16 @@ export class Vehicle {
             e.add(i);
         let a = (this.posObj = new THREE.Object3D());
         (a.matrixAutoUpdate = !1), a.add(e), t.add(a);
+    }
+    updateBridgeRenderOrder() {
+        const renderOrder = this.gameObject.onBridge ? 2 : 0;
+        if (this.lastBridgeRenderOrder === renderOrder) {
+            return;
+        }
+        this.lastBridgeRenderOrder = renderOrder;
+        this.mainObj?.traverse((object) => {
+            object.renderOrder = renderOrder;
+        });
     }
     computeSpriteAnchorOffset(e) {
         var t = this.objectArt.getDrawOffset();

--- a/src/engine/util/MapTileIntersectHelper.ts
+++ b/src/engine/util/MapTileIntersectHelper.ts
@@ -41,36 +41,25 @@ export class MapTileIntersectHelper {
         this.map = map;
         this.scene = scene;
     }
-    getTileAtScreenPoint(screenPoint: Point): MapTile | undefined {
-        const viewport = this.scene.viewport;
-        if (rectContainsPoint(viewport, screenPoint)) {
-            const intersectedTiles = this.intersectTilesByScreenPos(screenPoint);
-            return intersectedTiles.length > 0 ? intersectedTiles[0] : undefined;
-        }
-        return undefined;
-    }
-    intersectTilesByScreenPos(screenPoint: Point): MapTile[] {
-        return measurePerformanceFeature('mapTileHitTest', () => isPerformanceFeatureEnabled('mapTileHitTest')
-            ? this.intersectTilesByScreenPosOptimized(screenPoint)
-            : this.intersectTilesByScreenPosLegacy(screenPoint));
-    }
-    private intersectTilesByScreenPosLegacy(screenPoint: Point): MapTile[] {
-        const origin = IsoCoords.worldToScreen(0, 0);
-        const pan = this.scene.cameraPan.getPan();
-        const worldScreenPos = {
-            x: screenPoint.x + origin.x + pan.x - this.scene.viewport.width / 2,
-            y: screenPoint.y + origin.y + pan.y - this.scene.viewport.height / 2
-        };
-        const worldPos = IsoCoords.screenToWorld(worldScreenPos.x, worldScreenPos.y);
-        const tileCoords = new THREE.Vector2(worldPos.x, worldPos.y)
-            .multiplyScalar(1 / Coords.LEPTONS_PER_TILE)
-            .floor();
-        const centerTile = this.map.tiles.getByMapCoords(tileCoords.x, tileCoords.y);
-        if (!centerTile) {
-            console.warn(`Tile coordinates (${tileCoords.x},${tileCoords.y}) out of range`);
-            return [];
-        }
+    private collectCandidateTiles(centerTile: MapTile, tileElevation: number): MapTile[] {
         const candidateTiles: MapTile[] = [];
+        if (tileElevation) {
+            const radius = Math.max(4, Math.ceil(Math.abs(tileElevation)) + 4);
+            const seen = new Set<string>();
+            for (let dx = -radius; dx <= radius; dx += 1) {
+                for (let dy = -radius; dy <= radius; dy += 1) {
+                    const tile = this.map.tiles.getByMapCoords(centerTile.rx + dx, centerTile.ry + dy);
+                    if (tile) {
+                        const key = `${tile.rx},${tile.ry}`;
+                        if (!seen.has(key)) {
+                            seen.add(key);
+                            candidateTiles.push(tile);
+                        }
+                    }
+                }
+            }
+            return candidateTiles;
+        }
         for (let offset = 0; offset < 30; offset++) {
             const testCoords = [
                 { x: centerTile.rx + offset, y: centerTile.ry + offset },
@@ -84,14 +73,58 @@ export class MapTileIntersectHelper {
                 }
             }
         }
+        return candidateTiles;
+    }
+    getTileAtScreenPoint(screenPoint: Point, tileElevation: number = 0): MapTile | undefined {
+        const viewport = this.scene.viewport;
+        if (rectContainsPoint(viewport, screenPoint)) {
+            const intersectedTiles = this.intersectTilesByScreenPos(screenPoint, tileElevation);
+            return intersectedTiles.length > 0 ? intersectedTiles[0] : undefined;
+        }
+        return undefined;
+    }
+    getTileCenterScreenPoint(tile: MapTile, tileElevation: number = 0): Point {
+        const viewport = this.scene.viewport;
+        const origin = IsoCoords.worldToScreen(0, 0);
+        const pan = this.scene.cameraPan.getPan();
+        const screenPos = IsoCoords.tile3dToScreen(tile.rx + 0.5, tile.ry + 0.5, tile.z + tileElevation);
+        return {
+            x: screenPos.x - origin.x - pan.x + viewport.x + viewport.width / 2,
+            y: screenPos.y - origin.y - pan.y + viewport.y + viewport.height / 2
+        };
+    }
+    intersectTilesByScreenPos(screenPoint: Point, tileElevation: number = 0): MapTile[] {
+        return measurePerformanceFeature('mapTileHitTest', () => isPerformanceFeatureEnabled('mapTileHitTest')
+            ? this.intersectTilesByScreenPosOptimized(screenPoint, tileElevation)
+            : this.intersectTilesByScreenPosLegacy(screenPoint, tileElevation));
+    }
+    private intersectTilesByScreenPosLegacy(screenPoint: Point, tileElevation: number = 0): MapTile[] {
+        const origin = IsoCoords.worldToScreen(0, 0);
+        const pan = this.scene.cameraPan.getPan();
+        const worldScreenPos = {
+            x: screenPoint.x + origin.x + pan.x - this.scene.viewport.width / 2,
+            y: screenPoint.y + origin.y + pan.y - this.scene.viewport.height / 2
+        };
+        const projectedWorldScreenY = worldScreenPos.y + IsoCoords.tileHeightToScreen(tileElevation);
+        const worldPos = IsoCoords.screenToWorld(worldScreenPos.x, projectedWorldScreenY);
+        const tileCoords = new THREE.Vector2(worldPos.x, worldPos.y)
+            .multiplyScalar(1 / Coords.LEPTONS_PER_TILE)
+            .floor();
+        const centerTile = this.map.tiles.getByMapCoords(tileCoords.x, tileCoords.y);
+        if (!centerTile) {
+            console.warn(`Tile coordinates (${tileCoords.x},${tileCoords.y}) out of range`);
+            return [];
+        }
+        const candidateTiles = this.collectCandidateTiles(centerTile, tileElevation);
         const intersectedTiles: MapTile[] = [];
         const triangle = new THREE.Triangle();
         const testPoint = new THREE.Vector3(worldScreenPos.x, 0, worldScreenPos.y);
         for (const tile of candidateTiles) {
-            const corner1 = IsoCoords.tile3dToScreen(tile.rx, tile.ry, tile.z);
-            const corner2 = IsoCoords.tile3dToScreen(tile.rx, tile.ry + 1.1, tile.z);
-            const corner3 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry, tile.z);
-            const corner4 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry + 1.1, tile.z);
+            const testHeight = tile.z + tileElevation;
+            const corner1 = IsoCoords.tile3dToScreen(tile.rx, tile.ry, testHeight);
+            const corner2 = IsoCoords.tile3dToScreen(tile.rx, tile.ry + 1.1, testHeight);
+            const corner3 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry, testHeight);
+            const corner4 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry + 1.1, testHeight);
             triangle.a.set(corner1.x, 0, corner1.y);
             triangle.b.set(corner2.x, 0, corner2.y);
             triangle.c.set(corner3.x, 0, corner3.y);
@@ -108,11 +141,11 @@ export class MapTileIntersectHelper {
             return this.intersectTilesByScreenPosLegacy({
                 x: screenPoint.x,
                 y: screenPoint.y - IsoCoords.tileHeightToScreen(1)
-            });
+            }, tileElevation);
         }
         return intersectedTiles;
     }
-    private intersectTilesByScreenPosOptimized(screenPoint: Point): MapTile[] {
+    private intersectTilesByScreenPosOptimized(screenPoint: Point, tileElevation: number = 0): MapTile[] {
         const triangle = this.intersectTriangle ?? (this.intersectTriangle = new THREE.Triangle());
         const testPoint = this.intersectPoint ?? (this.intersectPoint = new THREE.Vector3());
         const intersectedTiles = this.intersectedTilesScratch;
@@ -124,7 +157,8 @@ export class MapTileIntersectHelper {
             intersectedTiles.length = 0;
             const worldScreenX = screenPoint.x + origin.x + pan.x - this.scene.viewport.width / 2;
             const worldScreenY = currentY + origin.y + pan.y - this.scene.viewport.height / 2;
-            const worldPos = IsoCoords.screenToWorld(worldScreenX, worldScreenY);
+            const projectedWorldScreenY = worldScreenY + IsoCoords.tileHeightToScreen(tileElevation);
+            const worldPos = IsoCoords.screenToWorld(worldScreenX, projectedWorldScreenY);
             const tileX = Math.floor(worldPos.x / Coords.LEPTONS_PER_TILE);
             const tileY = Math.floor(worldPos.y / Coords.LEPTONS_PER_TILE);
             const centerTile = this.map.tiles.getByMapCoords(tileX, tileY);
@@ -133,21 +167,12 @@ export class MapTileIntersectHelper {
                 return [];
             }
             testPoint.set(worldScreenX, 0, worldScreenY);
-            for (let offset = 0; offset < 30; offset += 1) {
-                const testCoords = [
-                    { x: centerTile.rx + offset, y: centerTile.ry + offset },
-                    { x: centerTile.rx + offset + 1, y: centerTile.ry + offset },
-                    { x: centerTile.rx + offset, y: centerTile.ry + offset + 1 }
-                ];
-                for (const coord of testCoords) {
-                    const tile = this.map.tiles.getByMapCoords(coord.x, coord.y);
-                    if (!tile) {
-                        continue;
-                    }
-                    const corner1 = IsoCoords.tile3dToScreen(tile.rx, tile.ry, tile.z);
-                    const corner2 = IsoCoords.tile3dToScreen(tile.rx, tile.ry + 1.1, tile.z);
-                    const corner3 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry, tile.z);
-                    const corner4 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry + 1.1, tile.z);
+            for (const tile of this.collectCandidateTiles(centerTile, tileElevation)) {
+                    const testHeight = tile.z + tileElevation;
+                    const corner1 = IsoCoords.tile3dToScreen(tile.rx, tile.ry, testHeight);
+                    const corner2 = IsoCoords.tile3dToScreen(tile.rx, tile.ry + 1.1, testHeight);
+                    const corner3 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry, testHeight);
+                    const corner4 = IsoCoords.tile3dToScreen(tile.rx + 1.1, tile.ry + 1.1, testHeight);
                     triangle.a.set(corner1.x, 0, corner1.y);
                     triangle.b.set(corner2.x, 0, corner2.y);
                     triangle.c.set(corner3.x, 0, corner3.y);
@@ -159,7 +184,6 @@ export class MapTileIntersectHelper {
                     if (intersects1 || intersects2) {
                         intersectedTiles.unshift(tile);
                     }
-                }
             }
             if (intersectedTiles.length > 0) {
                 return [...intersectedTiles];

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -9,7 +9,7 @@ import { BoxedVar } from "../util/BoxedVar";
 import { StartingUnitsGenerator } from "./StartingUnitsGenerator";
 import { CardinalTileFinder } from "./map/tileFinder/CardinalTileFinder";
 import { SpeedType } from "./type/SpeedType";
-import { Target } from "./Target";
+import { Target, TargetBridgeMode } from "./Target";
 import { BridgeOverlayTypes } from "./map/BridgeOverlayTypes";
 import { fnv32a, isBetween } from "../util/math";
 import { GameEventBus } from "./GameEventBus";
@@ -561,8 +561,8 @@ export class Game {
         const rules = this.rules.getSuperWeapon(name);
         return new SuperWeapon(name, rules, owner, isReady);
     }
-    createTarget(obj: any, tile: any) {
-        return new Target(obj, tile, this.map.tileOccupation);
+    createTarget(obj: any, tile: any, bridgeMode: TargetBridgeMode = TargetBridgeMode.Auto) {
+        return new Target(obj, tile, this.map.tileOccupation, bridgeMode);
     }
     isValidTarget(obj: any): boolean {
         if (obj) {

--- a/src/game/Target.ts
+++ b/src/game/Target.ts
@@ -1,18 +1,33 @@
 import { Coords } from './Coords';
+import { ZoneType } from './gameobject/unit/ZoneType';
 import { LandType } from './type/LandType';
+import { LocomotorType } from './type/LocomotorType';
+import { MovementZone } from './type/MovementZone';
+import { SpeedType } from './type/SpeedType';
+
+export enum TargetBridgeMode {
+    Auto = 0,
+    Ground = 1,
+    Bridge = 2,
+}
+
 export class Target {
     private tileOccupation: any;
     private isOre: boolean;
     private bridge?: any;
+    private bridgeMode: TargetBridgeMode;
     public tile: any;
     public obj?: any;
-    constructor(obj: any, tile: any, tileOccupation: any) {
+    constructor(obj: any, tile: any, tileOccupation: any, bridgeMode: TargetBridgeMode = TargetBridgeMode.Auto) {
         this.tileOccupation = tileOccupation;
         this.isOre = false;
+        this.bridgeMode = bridgeMode;
         if (obj) {
             if (obj.isOverlay() && obj.isBridge()) {
                 this.bridge = obj;
+                this.obj = obj;
                 this.tile = tile;
+                this.bridgeMode = TargetBridgeMode.Bridge;
             }
             else if (obj.isOverlay() && obj.isTiberium()) {
                 this.isOre = true;
@@ -27,7 +42,11 @@ export class Target {
             if (tile.landType === LandType.Tiberium) {
                 this.isOre = true;
             }
-            if (tile.onBridgeLandType !== undefined) {
+            if (bridgeMode === TargetBridgeMode.Bridge) {
+                this.bridge = tileOccupation.getBridgeOnTile(tile);
+            }
+            else if (bridgeMode === TargetBridgeMode.Auto &&
+                tile.onBridgeLandType !== undefined) {
                 this.bridge = tileOccupation.getBridgeOnTile(tile);
             }
             this.tile = tile;
@@ -45,12 +64,35 @@ export class Target {
             : Coords.tile3dToWorld(this.tile.rx + 0.5, this.tile.ry + 0.5, this.tile.z + (this.bridge?.tileElevation ?? 0));
     }
     isBridge(): boolean {
-        return !this.obj && !!this.bridge;
+        return !!this.bridge;
     }
     getBridge() {
         return (this.bridge ||
             (this.obj?.isUnit() && this.obj.onBridge
                 ? this.tileOccupation.getBridgeOnTile(this.obj.tile)
                 : undefined));
+    }
+    getBridgeFor(sourceObject?: any) {
+        if (sourceObject && Target.usesGroundLayerUnderBridge(sourceObject)) {
+            return undefined;
+        }
+        return this.getBridge();
+    }
+    getBridgeMode(): TargetBridgeMode {
+        return this.bridgeMode;
+    }
+    hasExplicitBridgeMode(): boolean {
+        return this.bridgeMode !== TargetBridgeMode.Auto;
+    }
+    static usesGroundLayerUnderBridge(sourceObject: any): boolean {
+        const rules = sourceObject?.rules;
+        return !!rules &&
+            (rules.naval ||
+                rules.waterBound ||
+                rules.locomotor === LocomotorType.Ship ||
+                sourceObject.zone === ZoneType.Water ||
+                rules.movementZone === MovementZone.Water ||
+                rules.speedType === SpeedType.Float ||
+                rules.speedType === SpeedType.FloatBeach);
     }
 }

--- a/src/game/action/OrderUnitsAction.ts
+++ b/src/game/action/OrderUnitsAction.ts
@@ -10,6 +10,7 @@ import { DeployNotAllowedEvent } from "@/game/event/DeployNotAllowedEvent";
 import { isNotNullOrUndefined } from "@/util/typeGuard";
 import { ScatterPositionHelper } from "@/game/gameobject/unit/ScatterPositionHelper";
 import { ActionType } from "@/game/action/ActionType";
+import { TargetBridgeMode } from "@/game/Target";
 export const ORDER_UNIT_LIMIT = 128;
 export class OrderUnitsAction extends Action {
     private game: any;
@@ -38,20 +39,26 @@ export class OrderUnitsAction extends Action {
             const ry = stream.readUint16();
             this.queue = version > 2 && Boolean(stream.readUint8());
             let targetObject: any;
+            let bridgeMode = TargetBridgeMode.Auto;
             if (version > 3) {
                 const objectId = stream.readUint32();
-                if (!this.game.getWorld().hasObjectId(objectId)) {
+                if (objectId === 0 && version > 4) {
+                    targetObject = undefined;
+                }
+                else if (!this.game.getWorld().hasObjectId(objectId)) {
                     this.isInvalid = true;
                     return;
                 }
-                targetObject = this.game.getObjectById(objectId);
+                else {
+                    targetObject = this.game.getObjectById(objectId);
+                }
             }
-            else {
-                targetObject = undefined;
+            if (version > 4) {
+                bridgeMode = stream.readUint8();
             }
             const tile = this.map.tiles.getByMapCoords(rx, ry);
             if (tile) {
-                this.target = this.game.createTarget(targetObject, tile);
+                this.target = this.game.createTarget(targetObject, tile, bridgeMode);
             }
             else {
                 this.isInvalid = true;
@@ -59,7 +66,7 @@ export class OrderUnitsAction extends Action {
         }
     }
     serialize(): Uint8Array {
-        let stream = new DataStream(11);
+        let stream = new DataStream(12);
         stream.dynamicSize = false;
         stream.writeUint8(this.orderType);
         let extraDataSize = 0;
@@ -69,12 +76,17 @@ export class OrderUnitsAction extends Action {
             stream.writeUint16(this.target.tile.ry);
             extraDataSize += 2;
             const objectId = (this.target.obj || this.target.getBridge())?.id;
-            if (this.queue || objectId !== undefined) {
+            const hasExplicitBridgeMode = this.target.hasExplicitBridgeMode?.();
+            if (this.queue || objectId !== undefined || hasExplicitBridgeMode) {
                 stream.writeUint8(Number(this.queue));
                 extraDataSize += 1;
             }
-            if (objectId !== undefined) {
-                stream.writeUint32(objectId);
+            if (objectId !== undefined || hasExplicitBridgeMode) {
+                stream.writeUint32(objectId ?? 0);
+                extraDataSize += 1;
+            }
+            if (hasExplicitBridgeMode) {
+                stream.writeUint8(this.target.getBridgeMode());
                 extraDataSize += 1;
             }
         }
@@ -145,18 +157,42 @@ export class OrderUnitsAction extends Action {
                 moveOrders.forEach((order: any) => processedOrders.push(order));
             }
             else {
-                const bridge = this.target.getBridge();
                 const forceMove = moveOrders[0].forceMove;
-                const units = moveOrders.map((order: any) => order.sourceObject);
-                const positions = new MovePositionHelper(this.map).findPositions(units, this.target.tile, bridge, forceMove);
-                moveOrders.forEach((order: any) => {
-                    const position = positions.get(order.sourceObject);
-                    const bridgeOnTile = !bridge || bridge.isHighBridge()
-                        ? this.map.tileOccupation.getBridgeOnTile(position)
-                        : bridge;
-                    const target = this.game.createTarget(bridgeOnTile, position);
-                    order.target = target;
-                    processedOrders.push(order);
+                const movePositionHelper = new MovePositionHelper(this.map);
+                const groups = new Map<any, any[]>();
+                for (const order of moveOrders) {
+                    const bridge = order.target.getBridgeFor(order.sourceObject);
+                    const group = groups.get(bridge) ?? [];
+                    group.push(order);
+                    groups.set(bridge, group);
+                }
+                groups.forEach((orders, bridge) => {
+                    const units = orders.map((order: any) => order.sourceObject);
+                    const positions = movePositionHelper.findPositions(units, this.target.tile, bridge, forceMove);
+                    orders.forEach((order: any) => {
+                        const position = positions.get(order.sourceObject);
+                        if (!position) {
+                            return;
+                        }
+                        const bridgeOnTile = bridge
+                            ? (bridge.isHighBridge()
+                                ? this.map.tileOccupation.getBridgeOnTile(position)
+                                : bridge)
+                            : undefined;
+                        // A move target is a LOCATION, not the bridge structure: leave
+                        // obj undefined and let TargetBridgeMode.Bridge re-attach the
+                        // bridge via the tile. Passing the bridge as obj makes
+                        // MoveOrder.isValid() treat it as an (unmovable) overlay object
+                        // and silently drop the order, so ground units never move onto
+                        // the bridge.
+                        const target = this.game.createTarget(
+                            undefined,
+                            position,
+                            bridgeOnTile ? TargetBridgeMode.Bridge : TargetBridgeMode.Ground,
+                        );
+                        order.target = target;
+                        processedOrders.push(order);
+                    });
                 });
             }
         }
@@ -168,7 +204,13 @@ export class OrderUnitsAction extends Action {
             scatterOrders.forEach((order: any) => {
                 const position = scatterPositions.get(order.sourceObject);
                 if (position) {
-                    const target = this.game.createTarget(position.onBridge, position.tile);
+                    // Same as the move case: a scatter destination is a location, not
+                    // the bridge object — keep obj undefined so the order isn't dropped.
+                    const target = this.game.createTarget(
+                        undefined,
+                        position.tile,
+                        position.onBridge ? TargetBridgeMode.Bridge : TargetBridgeMode.Ground,
+                    );
                     order.target = target;
                     processedOrders.push(order);
                 }

--- a/src/game/api/ActionsApi.ts
+++ b/src/game/api/ActionsApi.ts
@@ -1,6 +1,7 @@
 import { ActionType } from '@/game/action/ActionType';
 import { UpdateType } from '@/game/action/UpdateQueueAction';
 import { DebugCommand, DebugCommandType } from '@/game/action/DebugAction';
+import { TargetBridgeMode } from '@/game/Target';
 interface Tile {
     x: number;
     y: number;
@@ -38,7 +39,7 @@ interface Game {
         hasObjectId(id: number): boolean;
     };
     getObjectById(id: number): any;
-    createTarget(object: any, tile: any): Target;
+    createTarget(object: any, tile: any, bridgeMode?: TargetBridgeMode): Target;
 }
 interface LocalPlayer {
     name: string;
@@ -184,7 +185,10 @@ export class ActionsApi {
                 targetObject = this.game.getObjectById(targetX);
                 targetTile = targetObject.tile;
             }
-            target = this.game.createTarget(targetObject, targetTile);
+            const bridgeMode = targetY !== undefined && useBridge !== undefined
+                ? (useBridge ? TargetBridgeMode.Bridge : TargetBridgeMode.Ground)
+                : TargetBridgeMode.Auto;
+            target = this.game.createTarget(targetObject, targetTile, bridgeMode);
         }
         this.createAndPushAction(ActionType.OrderUnits, (action) => {
             action.orderType = orderType;

--- a/src/game/gameobject/task/EnterTransportTask.ts
+++ b/src/game/gameobject/task/EnterTransportTask.ts
@@ -117,7 +117,13 @@ export class EnterTransportTask extends Task {
             if (!this.isAllowed(unit)) {
                 return true;
             }
-            if (!this.game.map.tileOccupation.isTileOccupiedBy(unit.tile, this.target)) {
+            // The passenger must be on the SAME layer as the transport to board.
+            // isTileOccupiedBy is purely coordinate-based, so without this a unit on
+            // a bridge deck would "board" a transport floating in the water directly
+            // below it (same rx,ry, different layer) without ever leaving the bridge.
+            const coLocated = this.game.map.tileOccupation.isTileOccupiedBy(unit.tile, this.target) &&
+                !!unit.onBridge === !!this.target.onBridge;
+            if (!coLocated) {
                 if (this.movePerformed) {
                     return true;
                 }

--- a/src/game/gameobject/task/move/MoveTask.ts
+++ b/src/game/gameobject/task/move/MoveTask.ts
@@ -13,7 +13,7 @@ import AppLogger from "@/util/logger";
 const Logger = AppLogger;
 import { Coords } from "@/game/Coords";
 import { TaskStatus } from "@/game/gameobject/task/system/TaskStatus";
-import { ZoneType } from "@/game/gameobject/unit/ZoneType";
+import { getZoneType, ZoneType } from "@/game/gameobject/unit/ZoneType";
 import { LocomotorFactory } from "@/game/gameobject/locomotor/LocomotorFactory";
 import { RandomTileFinder } from "@/game/map/tileFinder/RandomTileFinder";
 import { ObjectTeleportEvent } from "@/game/event/ObjectTeleportEvent";
@@ -29,6 +29,7 @@ import type { Bridge } from "@/game/gameobject/Bridge";
 import type { Unit } from "@/game/gameobject/Unit";
 import type { Locomotor } from "@/game/gameobject/locomotor/Locomotor";
 import type { Weapon } from "@/game/gameobject/Weapon";
+import { Target } from "@/game/Target";
 const VELOCITY_FACTOR = 1.5;
 const MAX_PLANNING_TICKS = 200;
 const WAIT_TICKS = 40;
@@ -118,6 +119,7 @@ export class MoveTask extends Task {
         if (unit.moveTrait.locomotor === undefined) {
             unit.moveTrait.locomotor = new LocomotorFactory(this.game).create(unit);
         }
+        this.ensureGroundLayerUnderBridge(unit);
         if (unit.moveTrait.lastTargetOffset) {
             this.targetOffset = unit.moveTrait.lastTargetOffset;
         }
@@ -194,25 +196,33 @@ export class MoveTask extends Task {
     }
     private computeDirectJumpPath(unit: Unit): PathNode[] {
         const map = this.game.map;
-        const unitBridge = unit.onBridge
+        const canUseBridgeLayer = !Target.usesGroundLayerUnderBridge(unit);
+        const unitBridge = canUseBridgeLayer && unit.onBridge
             ? map.tileOccupation.getBridgeOnTile(unit.tile)
             : undefined;
         let targetTile = this.targetTile;
-        let targetBridge = this.toBridge
+        let targetBridge = canUseBridgeLayer && this.toBridge
             ? map.tileOccupation.getBridgeOnTile(this.targetTile)
             : undefined;
         const ignoredBlockers = this.options?.ignoredBlockers;
-        const finder = new RadialTileFinder(map.tiles, map.mapBounds, targetTile, { width: 1, height: 1 }, 0, 5, (tile) => map.terrain.getPassableSpeed(tile, unit.rules.speedType, unit.isInfantry(), !!tile.onBridgeLandType, ignoredBlockers) > 0 &&
-            !map.terrain
-                .findObstacles({ tile, onBridge: !!tile.onBridgeLandType }, unit)
-                .find((obstacle) => !ignoredBlockers?.includes(obstacle.obj)));
+        const finder = new RadialTileFinder(map.tiles, map.mapBounds, targetTile, { width: 1, height: 1 }, 0, 5, (tile) => {
+            const bridge = canUseBridgeLayer
+                ? map.tileOccupation.getBridgeOnTile(tile)
+                : undefined;
+            return (map.terrain.getPassableSpeed(tile, unit.rules.speedType, unit.isInfantry(), !!bridge, ignoredBlockers) > 0 &&
+                !map.terrain
+                    .findObstacles({ tile, onBridge: bridge }, unit)
+                    .find((obstacle) => !ignoredBlockers?.includes(obstacle.obj)));
+        });
         const newTile = finder.getNextTile();
         if (!newTile) {
             return [];
         }
         if (newTile !== targetTile) {
             targetTile = newTile;
-            targetBridge = map.tileOccupation.getBridgeOnTile(targetTile);
+            targetBridge = canUseBridgeLayer
+                ? map.tileOccupation.getBridgeOnTile(targetTile)
+                : undefined;
         }
         return [
             { tile: targetTile, onBridge: targetBridge },
@@ -220,14 +230,17 @@ export class MoveTask extends Task {
         ];
     }
     private computeGroundPath(unit: Unit): GroundPathPlan {
+        const forceGroundLayer = Target.usesGroundLayerUnderBridge(unit);
         let startTile = unit.tile;
-        let startBridge = unit.onBridge
+        let startBridge = !forceGroundLayer && unit.onBridge
             ? this.game.map.tileOccupation.getBridgeOnTile(startTile)
             : undefined;
         if (unit.moveTrait.moveState === MoveState.Moving &&
             unit.moveTrait.currentWaypoint) {
             startTile = unit.moveTrait.currentWaypoint.tile;
-            startBridge = unit.moveTrait.currentWaypoint.onBridge;
+            startBridge = forceGroundLayer
+                ? undefined
+                : unit.moveTrait.currentWaypoint.onBridge;
         }
         const plan: GroundPathPlan = {
             path: [],
@@ -277,18 +290,29 @@ export class MoveTask extends Task {
             ])
         ];
         const allBlockedNodes = [...this.blockedPathNodes, ...plan.blockedPathNodes];
-        const path = this.game.map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), startTile, !!startBridge, this.targetTile, this.toBridge, {
+        const hasExcludedNodes = forceGroundLayer || this.allObstaclesAreBlockers || !!allBlockedNodes.length;
+        const path = this.game.map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), startTile, !!startBridge, this.targetTile, forceGroundLayer ? false : this.toBridge, {
             maxExpandedNodes: this.allObstaclesAreBlockers
                 ? Math.min(300, this.options?.maxExpandedPathNodes ?? Number.POSITIVE_INFINITY)
                 : this.options?.maxExpandedPathNodes,
             bestEffort: !this.options?.strictCloseEnough,
             ignoredBlockers: allIgnoredBlockers,
-            excludeTiles: this.allObstaclesAreBlockers || allBlockedNodes.length
-                ? (node) => this.nodeIsBlockedForPathfinding(node, unit, allIgnoredBlockers, allBlockedNodes)
+            excludeTiles: hasExcludedNodes
+                ? (node) => (forceGroundLayer && !!node.onBridge) ||
+                    ((this.allObstaclesAreBlockers || !!allBlockedNodes.length) &&
+                        this.nodeIsBlockedForPathfinding(node, unit, allIgnoredBlockers, allBlockedNodes))
                 : undefined
         });
         plan.path = path;
         return plan;
+    }
+    private ensureGroundLayerUnderBridge(unit: Unit): void {
+        if (!Target.usesGroundLayerUnderBridge(unit) || !unit.onBridge) {
+            return;
+        }
+        unit.onBridge = false;
+        unit.position.tileElevation = 0;
+        unit.zone = getZoneType(unit.tile.landType);
     }
     private nodeIsBlockedForPathfinding(node: PathNode, unit: Unit, ignoredBlockers: GameObject[], blockedNodes: BlockedPathNode[]): boolean {
         if (this.allObstaclesAreBlockers) {
@@ -416,6 +440,7 @@ export class MoveTask extends Task {
             return false;
         }
         if (this.needsPathUpdate) {
+            this.ensureGroundLayerUnderBridge(unit);
             if (unit.moveTrait.moveState === MoveState.PlanMove) {
                 this.inPlanningForTicks = undefined;
                 unit.moveTrait.currentWaypoint = undefined;
@@ -462,12 +487,12 @@ export class MoveTask extends Task {
                     return true;
                 }
                 let relocTile = unit.tile;
-                let relocBridge = unit.onBridge
+                let relocBridge = !Target.usesGroundLayerUnderBridge(unit) && unit.onBridge
                     ? map.tileOccupation.getBridgeOnTile(relocTile)
                     : undefined;
                 if (notCloseEnough) {
                     relocTile = this.targetTile;
-                    relocBridge = this.toBridge
+                    relocBridge = !Target.usesGroundLayerUnderBridge(unit) && this.toBridge
                         ? map.tileOccupation.getBridgeOnTile(relocTile)
                         : undefined;
                 }
@@ -479,7 +504,8 @@ export class MoveTask extends Task {
                     this.log(unit, "bail_no_free_dest");
                     return true;
                 }
-                const newBridge = !relocBridge || relocBridge.isHighBridge()
+                const newBridge = !Target.usesGroundLayerUnderBridge(unit) &&
+                    (!relocBridge || relocBridge.isHighBridge())
                     ? map.tileOccupation.getBridgeOnTile(newTile)
                     : undefined;
                 this.updateTarget(newTile, !!newBridge);
@@ -534,6 +560,12 @@ export class MoveTask extends Task {
                 for (const node of pathToCheck) {
                     if (node.onBridge?.isDestroyed) {
                         node.onBridge = undefined;
+                    }
+                    if (Target.usesGroundLayerUnderBridge(unit) && node.onBridge) {
+                        this.needsPathUpdate = true;
+                        unit.moveTrait.currentWaypoint = undefined;
+                        unit.moveTrait.moveState = MoveState.ReachedNextWaypoint;
+                        return this.onTick(unit);
                     }
                 }
                 for (const node of pathToCheck) {
@@ -681,12 +713,14 @@ export class MoveTask extends Task {
                             let alternatePath: PathNode[] = [];
                             if (freeWaypointIndex !== -1) {
                                 const targetWaypoint = this.path![freeWaypointIndex];
-                                alternatePath = map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), unit.tile, unit.onBridge, targetWaypoint.tile, !!targetWaypoint.onBridge, {
+                                const forceGroundLayer = Target.usesGroundLayerUnderBridge(unit);
+                                alternatePath = map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), unit.tile, forceGroundLayer ? false : unit.onBridge, targetWaypoint.tile, forceGroundLayer ? false : !!targetWaypoint.onBridge, {
                                     maxExpandedNodes: 15,
                                     bestEffort: false,
-                                    excludeTiles: (testNode) => !!map.terrain
-                                        .findObstacles(testNode, unit)
-                                        .filter((obstacle) => !this.options?.ignoredBlockers?.includes(obstacle.obj)).length,
+                                    excludeTiles: (testNode) => (forceGroundLayer && !!testNode.onBridge) ||
+                                        !!map.terrain
+                                            .findObstacles(testNode, unit)
+                                            .filter((obstacle) => !this.options?.ignoredBlockers?.includes(obstacle.obj)).length,
                                     ignoredBlockers: this.options?.ignoredBlockers
                                 });
                             }
@@ -785,10 +819,12 @@ export class MoveTask extends Task {
                                 const backtrackIndex = findIndexReverse(this.path!.slice(0, nodeIndex - 5), (waypoint) => !map.terrain.findObstacles(waypoint, unit).length);
                                 if (backtrackIndex !== -1) {
                                     const backtrackTarget = this.path![backtrackIndex];
-                                    const backtrackPath = map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), unit.tile, unit.onBridge, backtrackTarget.tile, !!backtrackTarget.onBridge, {
+                                    const forceGroundLayer = Target.usesGroundLayerUnderBridge(unit);
+                                    const backtrackPath = map.terrain.computePath(unit.rules.speedType, unit.isInfantry(), unit.tile, forceGroundLayer ? false : unit.onBridge, backtrackTarget.tile, forceGroundLayer ? false : !!backtrackTarget.onBridge, {
                                         maxExpandedNodes: 15,
                                         bestEffort: false,
-                                        excludeTiles: (testNode) => !!map.terrain.findObstacles(testNode, unit).length ||
+                                        excludeTiles: (testNode) => (forceGroundLayer && !!testNode.onBridge) ||
+                                            !!map.terrain.findObstacles(testNode, unit).length ||
                                             this.path!.findIndex((waypoint) => waypoint.tile === testNode.tile &&
                                                 waypoint.onBridge === testNode.onBridge) > backtrackIndex
                                     });
@@ -861,15 +897,18 @@ export class MoveTask extends Task {
                     unit.position.moveByLeptons(distance.x, distance.z, allowOutOfBounds);
                 }
                 if (unit.tile !== oldTile) {
-                    const oldBridge = unit.onBridge
+                    const canUseBridgeLayer = !Target.usesGroundLayerUnderBridge(unit);
+                    const oldBridge = canUseBridgeLayer && unit.onBridge
                         ? this.game.map.tileOccupation.getBridgeOnTile(oldTile)
                         : undefined;
                     const currentNode = findReverse(this.path!, (node) => node.tile === unit.tile);
-                    const newBridge = currentNode
-                        ? currentNode.onBridge
-                        : oldBridge || unit.moveTrait.currentWaypoint!.onBridge
-                            ? this.game.map.tileOccupation.getBridgeOnTile(unit.tile)
-                            : undefined;
+                    const newBridge = canUseBridgeLayer
+                        ? currentNode
+                            ? currentNode.onBridge
+                            : oldBridge || unit.moveTrait.currentWaypoint!.onBridge
+                                ? this.game.map.tileOccupation.getBridgeOnTile(unit.tile)
+                                : undefined
+                        : undefined;
                     unit.moveTrait.handleTileChange(oldTile, newBridge, false, this.game, isTeleport);
                     if (isTeleport) {
                         unit.moveTrait.lastTeleportTick = this.game.currentTick;
@@ -920,14 +959,17 @@ export class MoveTask extends Task {
             return relocTile;
         }
         else {
+            const forceGroundLayer = Target.usesGroundLayerUnderBridge(unit);
+            const unitOnBridge = forceGroundLayer ? false : unit.onBridge;
             const islandMap = !this.options?.ignoredBlockers?.length &&
-                map.terrain.getPassableSpeed(unit.tile, unit.rules.speedType, unit.isInfantry(), unit.onBridge)
+                map.terrain.getPassableSpeed(unit.tile, unit.rules.speedType, unit.isInfantry(), unitOnBridge)
                 ? this.game.map.terrain.getIslandIdMap(unit.rules.speedType, unit.isInfantry())
                 : undefined;
-            const unitIslandId = islandMap?.get(unit.tile, unit.onBridge);
+            const unitIslandId = islandMap?.get(unit.tile, unitOnBridge);
             const moveHelper = new MovePositionHelper(map);
             const finder = new RadialTileFinder(map.tiles, map.mapBounds, preferredTile, { width: 1, height: 1 }, 0, 5, (tile) => {
-                const bridge = !preferredBridge || preferredBridge.isHighBridge()
+                const bridge = !forceGroundLayer &&
+                    (!preferredBridge || preferredBridge.isHighBridge())
                     ? map.tileOccupation.getBridgeOnTile(tile)
                     : undefined;
                 return (!this.unreachableTargets.find((target) => target.tile === tile && target.toBridge === !!bridge) &&

--- a/src/game/gameobject/trait/MoveTrait.ts
+++ b/src/game/gameobject/trait/MoveTrait.ts
@@ -16,6 +16,7 @@ import { NotifyTileChange } from "@/game/gameobject/trait/interface/NotifyTileCh
 import { EnterTileEvent } from "@/game/event/EnterTileEvent";
 import { Vector3 } from "@/game/math/Vector3";
 import { NotifyElevationChange } from "@/game/trait/interface/NotifyElevationChange";
+import { Target } from "@/game/Target";
 interface GameObject {
     rules: any;
     veteranTrait?: any;
@@ -199,6 +200,14 @@ export class MoveTrait {
     }
     handleTileChange(oldTile: any, bridge: any, teleporting: boolean, gameState: GameState, isTeleport: boolean = false): void {
         const gameObject = this.gameObject;
+        if (Target.usesGroundLayerUnderBridge(gameObject)) {
+            bridge = undefined;
+            if (gameObject.onBridge) {
+                gameObject.onBridge = false;
+                gameObject.position.tileElevation = 0;
+                gameObject.zone = getZoneType(gameObject.tile.landType);
+            }
+        }
         gameState.map.tileOccupation.unoccupyTileRange(oldTile, gameObject);
         gameState.map.tileOccupation.occupyTileRange(gameObject.tile, gameObject);
         gameState.map.technosByTile.updateObject(gameObject);

--- a/src/game/gameobject/unit/MovePositionHelper.ts
+++ b/src/game/gameobject/unit/MovePositionHelper.ts
@@ -1,6 +1,7 @@
 import { RadialTileFinder } from '@/game/map/tileFinder/RadialTileFinder';
 import { MovementZone } from '@/game/type/MovementZone';
 import { SpeedType } from '@/game/type/SpeedType';
+import { Target } from '@/game/Target';
 interface GameObject {
     tile: Tile;
     rules: {
@@ -65,7 +66,7 @@ export class MovePositionHelper {
                     !(obj.rules.airportBound || (isSpecialCondition && obj.rules.balloonHover && !obj.rules.hoverAttack)) &&
                     !this.map.terrain.getPassableSpeed(candidateTile, SpeedType.Amphibious, false, !!bridge)) ||
                 (obj.rules.movementZone !== MovementZone.Fly &&
-                    !this.isEligibleTile(candidateTile, bridge, sourceBridge, targetTile))) {
+                    !this.isEligibleTile(candidateTile, this.eligibilityBridge(obj, bridge), sourceBridge, targetTile))) {
                 unplacedObjects.push(obj);
             }
             else {
@@ -90,7 +91,7 @@ export class MovePositionHelper {
                     obj.rules.airportBound ||
                     this.map.terrain.getPassableSpeed(nextTile, SpeedType.Amphibious, false, !!bridge)) &&
                 (obj.rules.movementZone === MovementZone.Fly ||
-                    this.isEligibleTile(nextTile, bridge, sourceBridge, targetTile))) {
+                    this.isEligibleTile(nextTile, this.eligibilityBridge(obj, bridge), sourceBridge, targetTile))) {
                 let assignedObjects = tileAssignments.get(nextTile);
                 if (!assignedObjects) {
                     assignedObjects = [];
@@ -118,6 +119,21 @@ export class MovePositionHelper {
             return existingObjects.filter(existing => existing.isInfantry()).length < maxInfantry;
         }
         return !existingObjects.length;
+    }
+    // A unit that travels the water layer UNDER bridges (naval) reaches the water
+    // beneath a HIGH bridge at ground level, so the deck above must not be treated as a
+    // layer it has to match — otherwise the destination tile fails the elevation check
+    // and the unit is bumped to the open water beside the bridge instead of stopping
+    // under it. Low bridges sit at water level and still block, so only ignore high ones.
+    // Units flagged tooBigToFitUnderBridge genuinely can't stop under a high bridge
+    // (MoveTask.canStopAtTile rejects it), so keep treating the deck as a blocker for
+    // them — otherwise they'd be sent under the deck only to bounce back out to the side.
+    private eligibilityBridge(obj: GameObject, tileBridge: Bridge | undefined): Bridge | undefined {
+        return tileBridge?.isHighBridge?.() &&
+            Target.usesGroundLayerUnderBridge(obj) &&
+            !(obj as any).rules?.tooBigToFitUnderBridge
+            ? undefined
+            : tileBridge;
     }
     public isEligibleTile(tile: Tile, tileBridge: Bridge | undefined, sourceBridge: Bridge | undefined, targetTile: Tile): boolean {
         if (sourceBridge?.isHighBridge() || tileBridge?.isHighBridge()) {

--- a/src/game/order/AttackMoveOrder.ts
+++ b/src/game/order/AttackMoveOrder.ts
@@ -28,7 +28,7 @@ export class AttackMoveOrder extends AttackOrder {
         }
         let isAllowed = this.isAllowed();
         if (isAllowed) {
-            const hasBridge = !!this.target.getBridge();
+            const hasBridge = !!this.target.getBridgeFor(this.sourceObject);
             const speedType = this.sourceObject.rules.speedType;
             const isInfantry = this.sourceObject.isInfantry();
             const canFly = this.sourceObject.rules.movementZone === MovementZone.Fly;
@@ -70,7 +70,7 @@ export class AttackMoveOrder extends AttackOrder {
             return [new AttackMoveTargetTask(this.game, this.target, weapon)];
         }
         return [
-            new AttackMoveTask(this.game, this.target.tile, !!this.target.getBridge(), { closeEnoughTiles: this.game.rules.general.closeEnough })
+            new AttackMoveTask(this.game, this.target.tile, !!this.target.getBridgeFor(this.sourceObject), { closeEnoughTiles: this.game.rules.general.closeEnough })
         ];
     }
     isTargetted(): boolean {
@@ -93,7 +93,7 @@ export class AttackMoveOrder extends AttackOrder {
                     }
                     else {
                         if (existingTask.constructor === AttackMoveTask) {
-                            existingTask.updateTarget(this.target.tile, !!this.target.getBridge());
+                            existingTask.updateTarget(this.target.tile, !!this.target.getBridgeFor(this.sourceObject));
                             taskList.splice(taskList.indexOf(existingTask) + 1);
                             unit.unitOrderTrait.clearOrders();
                             return false;

--- a/src/game/order/AttackOrder.ts
+++ b/src/game/order/AttackOrder.ts
@@ -119,6 +119,12 @@ export class AttackOrder extends Order {
             !weapon.warhead.rules.bombDisarm) {
             return false;
         }
+        if (!this.forceAttack &&
+            targetObj?.isOverlay?.() &&
+            targetObj.isBridge?.() &&
+            !weapon.warhead.rules.wall) {
+            return false;
+        }
         const canMoveOrInRange = (this.sourceObject.isUnit() &&
             this.sourceObject.moveTrait &&
             !this.sourceObject.moveTrait.isDisabled()) ||
@@ -139,6 +145,7 @@ export class AttackOrder extends Order {
         if (targetObj.isDestroyed || targetObj.isCrashing)
             return false;
         if (targetObj.isOverlay() &&
+            !targetObj.isBridge?.() &&
             (weapon.warhead.rules.wall ||
                 (weapon.warhead.rules.wood && targetObj.rules.armor === ArmorType.Wood)) &&
             !targetObj.isTechno()) {

--- a/src/game/order/EnterTransportOrder.ts
+++ b/src/game/order/EnterTransportOrder.ts
@@ -34,6 +34,13 @@ export class EnterTransportOrder extends Order {
     isAllowed(): boolean {
         const target = this.target.obj;
         const source = this.sourceObject;
+        // A unit stacked on a different layer than the transport (e.g. on a bridge
+        // deck while the transport floats in the water directly below) cannot board
+        // it — show NoOccupy instead of letting it teleport-board across layers.
+        if (this.game.map.tileOccupation.isTileOccupiedBy(source.tile, target) &&
+            !!source.onBridge !== !!target.onBridge) {
+            return false;
+        }
         return (source.zone !== ZoneType.Air &&
             target.zone !== ZoneType.Air &&
             target.transportTrait.unitFitsInside(source) &&

--- a/src/game/order/GuardAreaOrder.ts
+++ b/src/game/order/GuardAreaOrder.ts
@@ -41,7 +41,7 @@ export class GuardAreaOrder extends Order {
         const sourceObject = this.sourceObject;
         const tasks: (MoveTask | CallbackTask | GatherOreTask)[] = [];
         if (targetTile) {
-            tasks.push(new MoveTask(this.game, targetTile, !!this.target.getBridge(), {
+            tasks.push(new MoveTask(this.game, targetTile, !!this.target.getBridgeFor(this.sourceObject), {
                 closeEnoughTiles: this.game.rules.general.closeEnough,
             }));
         }

--- a/src/game/order/MoveOrder.ts
+++ b/src/game/order/MoveOrder.ts
@@ -37,7 +37,7 @@ export class MoveOrder extends Order {
             this.game.mapShroudTrait
                 .getPlayerShroud(this.sourceObject.owner)
                 ?.isShrouded(this.target.tile, this.target.obj?.tileElevation)) {
-            const hasBridge = !!this.target.getBridge();
+            const hasBridge = !!this.target.getBridgeFor(this.sourceObject);
             const speedType = this.sourceObject.rules.speedType;
             const isInfantry = this.sourceObject.isInfantry();
             const isFlying = this.sourceObject.rules.movementZone === MovementZone.Fly;
@@ -125,7 +125,7 @@ export class MoveOrder extends Order {
         if (sourceObject.isBuilding() && sourceObject.rules.undeploysInto) {
             return [
                 new UndeployIntoTask(this.game),
-                new MoveTask(this.game, this.target.tile, !!this.target.getBridge(), { closeEnoughTiles, forceMove: this.forceMove })
+                new MoveTask(this.game, this.target.tile, !!this.target.getBridgeFor(this.sourceObject), { closeEnoughTiles, forceMove: this.forceMove })
             ];
         }
         if (sourceObject.isUnit()) {
@@ -136,7 +136,7 @@ export class MoveOrder extends Order {
                 return [new MoveTargetTask(this.game, this.target.obj)];
             }
             return [
-                new MoveTask(this.game, this.target.tile, !!this.target.getBridge(), { closeEnoughTiles, forceMove: this.forceMove })
+                new MoveTask(this.game, this.target.tile, !!this.target.getBridgeFor(this.sourceObject), { closeEnoughTiles, forceMove: this.forceMove })
             ];
         }
         return undefined;
@@ -182,7 +182,7 @@ export class MoveOrder extends Order {
             const existingMoveTask = tasks.find((task: any) => task.constructor === MoveTask && !task.isCancelling());
             if (existingMoveTask) {
                 existingMoveTask.setForceMove(this.forceMove);
-                existingMoveTask.updateTarget(this.target.tile, !!this.target.getBridge());
+                existingMoveTask.updateTarget(this.target.tile, !!this.target.getBridgeFor(this.sourceObject));
                 if (existingMoveTask.children.length &&
                     existingMoveTask.children[0] instanceof AttackTask) {
                     existingMoveTask.children[0].cancel();

--- a/src/game/order/ScatterOrder.ts
+++ b/src/game/order/ScatterOrder.ts
@@ -27,7 +27,7 @@ export class ScatterOrder extends Order {
         return [
             new ScatterTask(this.game, {
                 tile: this.target.tile,
-                toBridge: !!this.target.getBridge(),
+                toBridge: !!this.target.getBridgeFor(this.sourceObject),
             }, undefined),
         ];
     }

--- a/src/gui/screen/game/worldInteraction/DefaultActionHandler.ts
+++ b/src/gui/screen/game/worldInteraction/DefaultActionHandler.ts
@@ -6,7 +6,7 @@ import { MoveOrder } from '@/game/order/MoveOrder';
 import { orderPriorities } from '@/game/order/orderPriorities';
 import { OrderFactory } from '@/game/order/OrderFactory';
 import { AttackOrder } from '@/game/order/AttackOrder';
-import { Target } from '@/game/Target';
+import { Target, TargetBridgeMode } from '@/game/Target';
 import { AttackMoveOrder } from '@/game/order/AttackMoveOrder';
 import { OrderFeedbackType } from '@/game/order/OrderFeedbackType';
 import { GuardAreaOrder } from '@/game/order/GuardAreaOrder';
@@ -93,12 +93,13 @@ export class DefaultActionHandler {
     private specialActions: any[] = [];
     private currentTarget?: any;
     private currentSelected?: any[];
+    private currentHover?: any;
     private mostSignificantAction?: any;
     get onOrder() {
         return this._onOrder.asEvent();
     }
     static factory(renderableManager: any, unitSelection: any, unitSelectionHandler: any, currentPlayer: any, map: any, game: any, audioVisualRules: any): DefaultActionHandler {
-        const handler = new DefaultActionHandler(renderableManager, currentPlayer, audioVisualRules, map.tileOccupation);
+        const handler = new DefaultActionHandler(renderableManager, currentPlayer, audioVisualRules, map);
         const selectAction = new SelectAction(game, unitSelectionHandler, currentPlayer);
         handler.selectAction = selectAction;
         if (currentPlayer && !currentPlayer.isObserver) {
@@ -126,11 +127,36 @@ export class DefaultActionHandler {
         }
         return handler;
     }
-    constructor(private readonly renderableManager: any, private readonly currentPlayer: any, private readonly audioVisualRules: any, private readonly tileOccupation: any) { }
+    constructor(private readonly renderableManager: any, private readonly currentPlayer: any, private readonly audioVisualRules: any, private readonly map: any) { }
     private createOrderTarget(hover: any): Target {
-        return new Target(hover?.gameObject, hover?.tile, this.tileOccupation);
+        return new Target(hover?.gameObject, hover?.tile, this.map.tileOccupation);
     }
-    private getDefaultAction(sourceObject: any, selected: any[], hover: any, target: any, filter: ActionFilter, force: boolean, allowTypeSelect: boolean, keyboardEvent: any, minimap: boolean): any {
+    private createTargetForAction(hover: any, sourceObject: any, action: any): Target {
+        if (action instanceof MoveOrder ||
+            action instanceof AttackMoveOrder ||
+            action instanceof GuardAreaOrder) {
+            const hoverObjectIsBridge = hover?.gameObject?.isOverlay?.() && hover.gameObject.isBridge?.();
+            const bridgeTile = hoverObjectIsBridge ? hover?.bridgeTile ?? hover.tile : hover?.bridgeTile;
+            if (!bridgeTile) {
+                return this.createOrderTarget(hover);
+            }
+            if (Target.usesGroundLayerUnderBridge(sourceObject)) {
+                // Ships/naval units travel the water layer. The water beneath a
+                // high bridge shares the deck tile's (rx,ry); hover.groundTile is
+                // the z=0 screen projection of the elevated deck and lands a couple
+                // tiles away on the (impassable) shore, so the move is rejected.
+                // Target the bridge tile itself in Ground mode so the unit heads to
+                // the water directly under the deck.
+                const groundTile = bridgeTile ?? hover?.groundTile ?? hover?.tile;
+                return groundTile
+                    ? new Target(undefined, groundTile, this.map.tileOccupation, TargetBridgeMode.Ground)
+                    : this.createOrderTarget(hover);
+            }
+            return new Target(undefined, bridgeTile, this.map.tileOccupation, TargetBridgeMode.Bridge);
+        }
+        return this.createOrderTarget(hover);
+    }
+    private getDefaultAction(sourceObject: any, selected: any[], hover: any, filter: ActionFilter, force: boolean, allowTypeSelect: boolean, keyboardEvent: any, minimap: boolean): any {
         const hoveredObject = hover.gameObject;
         const selectAction = this.selectAction.setForce(force).setTypeSelect(false);
         if (!sourceObject || sourceObject.owner !== this.currentPlayer || sourceObject.rules.spawned) {
@@ -153,21 +179,29 @@ export class DefaultActionHandler {
         const allWarpedOut = selected.every((unit) => unit.warpedOutTrait?.isActive?.());
         if (keyboardEvent?.ctrlKey && !allWarpedOut) {
             if (keyboardEvent.shiftKey) {
-                if (this.attackMoveAction?.set(sourceObject, target).isValid()) {
+                const target = this.attackMoveAction && this.createTargetForAction(hover, sourceObject, this.attackMoveAction);
+                if (target && this.attackMoveAction.set(sourceObject, target).isValid()) {
                     return this.attackMoveAction;
                 }
             }
             else if (keyboardEvent.altKey) {
-                if (this.guardAreaAction?.set(sourceObject, target).isValid()) {
+                const target = this.guardAreaAction && this.createTargetForAction(hover, sourceObject, this.guardAreaAction);
+                if (target && this.guardAreaAction.set(sourceObject, target).isValid()) {
                     return this.guardAreaAction;
                 }
             }
-            else if (this.forceAttackAction?.set(sourceObject, target).isValid()) {
-                return this.forceAttackAction;
+            else if (this.forceAttackAction) {
+                const target = this.createTargetForAction(hover, sourceObject, this.forceAttackAction);
+                if (this.forceAttackAction.set(sourceObject, target).isValid()) {
+                    return this.forceAttackAction;
+                }
             }
         }
-        if (keyboardEvent?.altKey && !allWarpedOut && this.forceMoveAction?.set(sourceObject, target).isValid()) {
-            return this.forceMoveAction;
+        if (keyboardEvent?.altKey && !allWarpedOut && this.forceMoveAction) {
+            const target = this.createTargetForAction(hover, sourceObject, this.forceMoveAction);
+            if (this.forceMoveAction.set(sourceObject, target).isValid()) {
+                return this.forceMoveAction;
+            }
         }
         for (const action of this.defaultActions) {
             if (action instanceof SelectAction) {
@@ -178,24 +212,31 @@ export class DefaultActionHandler {
             else if (!allWarpedOut &&
                 (!minimap || action.minimapAllowed) &&
                 !(action.singleSelectionRequired && selected.length > 1) &&
-                action.set(sourceObject, target).isValid()) {
+                action.set(sourceObject, this.createTargetForAction(hover, sourceObject, action)).isValid()) {
                 return action;
             }
         }
-        if (minimap && !allWarpedOut && this.forceMoveAction?.set(sourceObject, target).isValid()) {
-            return this.forceMoveAction;
+        if (minimap && !allWarpedOut && this.forceMoveAction) {
+            const target = this.createTargetForAction(hover, sourceObject, this.forceMoveAction);
+            if (this.forceMoveAction.set(sourceObject, target).isValid()) {
+                return this.forceMoveAction;
+            }
         }
         return undefined;
     }
-    private updateMostSignificantAction(selected: any[], hover: any, target: any, filter: ActionFilter, force: boolean, allowTypeSelect: boolean, keyboardEvent: any, minimap: boolean): any {
+    private updateMostSignificantAction(selected: any[], hover: any, filter: ActionFilter, force: boolean, allowTypeSelect: boolean, keyboardEvent: any, minimap: boolean): any {
         if (!selected.length) {
-            return this.getDefaultAction(undefined, selected, hover, target, filter, force, allowTypeSelect, keyboardEvent, minimap);
+            return this.getDefaultAction(undefined, selected, hover, filter, force, allowTypeSelect, keyboardEvent, minimap);
         }
         const actions = selected
             .map((unit) => {
-            const action = this.getDefaultAction(unit, selected, hover, target, filter, force, allowTypeSelect, keyboardEvent, minimap);
+            const action = this.getDefaultAction(unit, selected, hover, filter, force, allowTypeSelect, keyboardEvent, minimap);
             if (action) {
-                return { unit, action };
+                return {
+                    unit,
+                    action,
+                    target: action instanceof SelectAction ? undefined : action.target,
+                };
             }
             return undefined;
         })
@@ -206,7 +247,7 @@ export class DefaultActionHandler {
         }
         return actions.reduce((best: any, entry: any) => {
             if (!best) {
-                return entry.action instanceof SelectAction ? entry.action : entry.action.set(entry.unit, target);
+                return entry.action instanceof SelectAction ? entry.action : entry.action.set(entry.unit, entry.target);
             }
             const bestIndex = this.defaultActions.indexOf(best);
             const currentIndex = this.defaultActions.indexOf(entry.action);
@@ -218,7 +259,7 @@ export class DefaultActionHandler {
             return currentBeatsBest
                 ? entry.action instanceof SelectAction
                     ? entry.action
-                    : entry.action.set(entry.unit, target)
+                    : entry.action.set(entry.unit, entry.target)
                 : best;
         }, undefined);
     }
@@ -231,35 +272,48 @@ export class DefaultActionHandler {
         }
         if (!this.mostSignificantAction.isAllowed()) {
             const sourceObject = this.mostSignificantAction.sourceObject;
+            const target = this.mostSignificantAction.target;
             for (const unit of this.currentSelected) {
-                this.mostSignificantAction.set(unit, this.currentTarget);
+                this.mostSignificantAction.set(
+                    unit,
+                    this.currentHover
+                        ? this.createTargetForAction(this.currentHover, unit, this.mostSignificantAction)
+                        : this.currentTarget,
+                );
                 if (this.mostSignificantAction.isValid() && this.mostSignificantAction.isAllowed()) {
                     return this.mostSignificantAction.getPointerType(minimap, this.currentSelected);
                 }
             }
-            this.mostSignificantAction.set(sourceObject, this.currentTarget);
+            this.mostSignificantAction.set(sourceObject, target);
         }
         return this.mostSignificantAction.getPointerType(minimap, this.currentSelected);
     }
     update(hover: any, selected: any[], rightClickMove: boolean, keyboardEvent: any, minimap: boolean = false): void {
-        const target = (this.currentTarget = this.createOrderTarget(hover));
+        this.currentHover = hover;
         this.currentSelected = selected;
-        this.mostSignificantAction = this.updateMostSignificantAction(selected, hover, target, ActionFilter.All, rightClickMove, false, keyboardEvent, minimap);
+        this.mostSignificantAction = this.updateMostSignificantAction(selected, hover, ActionFilter.All, rightClickMove, false, keyboardEvent, minimap);
+        this.currentTarget = this.mostSignificantAction instanceof SelectAction
+            ? this.createOrderTarget(hover)
+            : this.mostSignificantAction?.target ?? this.createOrderTarget(hover);
     }
     execute(hover: any, selected: any[], filter: ActionFilter, force: boolean, allowTypeSelect: boolean, keyboardEvent: any, minimap: boolean = false): boolean {
-        const target = (this.currentTarget = this.createOrderTarget(hover));
+        this.currentHover = hover;
         this.currentSelected = selected;
-        this.mostSignificantAction = this.updateMostSignificantAction(selected, hover, target, filter, force, allowTypeSelect, keyboardEvent, minimap);
+        this.mostSignificantAction = this.updateMostSignificantAction(selected, hover, filter, force, allowTypeSelect, keyboardEvent, minimap);
         if (!this.mostSignificantAction) {
             return false;
         }
+        const target = (this.currentTarget = this.mostSignificantAction instanceof SelectAction
+            ? this.createOrderTarget(hover)
+            : this.mostSignificantAction.target);
         const allowed = this.mostSignificantAction.isAllowed();
         if (allowed) {
             if (this.mostSignificantAction instanceof MoveOrder ||
                 (this.mostSignificantAction instanceof AttackMoveOrder && !target.obj?.isTechno?.()) ||
                 this.mostSignificantAction instanceof GuardAreaOrder) {
                 this.renderableManager.createTransientAnim(this.audioVisualRules.moveFlash, (renderable: any) => {
-                    renderable.setPosition(Coords.tile3dToWorld(target.tile.rx + 0.5, target.tile.ry + 0.5, target.tile.z + (target.getBridge()?.tileElevation ?? 0)));
+                    const bridge = target.getBridgeFor?.(this.mostSignificantAction.sourceObject) ?? target.getBridge?.();
+                    renderable.setPosition(Coords.tile3dToWorld(target.tile.rx + 0.5, target.tile.ry + 0.5, target.tile.z + (bridge?.tileElevation ?? 0)));
                 });
             }
             else if (!(this.mostSignificantAction instanceof SelectAction) && !selected.includes(hover.gameObject)) {

--- a/src/gui/screen/game/worldInteraction/MapHoverHandler.ts
+++ b/src/gui/screen/game/worldInteraction/MapHoverHandler.ts
@@ -2,6 +2,14 @@ import * as THREE from 'three';
 import { EventDispatcher } from '@/util/event';
 import { Coords } from '@/game/Coords';
 export class MapHoverHandler {
+    // High-bridge decks are drawn offset UP by their tileElevation (≈4 cells), so the
+    // screen point of the deck is well above the tile's z=0 projection. The pick has to
+    // reach that far: the candidate radius must exceed the elevation (so the deck is even
+    // collected from the z=0 projection of the railing), and the accept distance must
+    // span the deck sprite's vertical extent — otherwise the railing/upper edge over open
+    // water can't be clicked.
+    private static readonly BRIDGE_PICK_RADIUS = 6;
+    private static readonly MAX_BRIDGE_PICK_DISTANCE = 72;
     private readonly _onHoverChange = new EventDispatcher<any, any>();
     private isActive = false;
     private needsUpdate = false;
@@ -12,6 +20,8 @@ export class MapHoverHandler {
     };
     private currentHoverEntity?: any;
     private currentHoverTile?: any;
+    private currentHoverGroundTile?: any;
+    private currentHoverBridgeTile?: any;
     constructor(private readonly entityIntersectHelper: any, private readonly mapTileIntersectHelper: any, private readonly map: any, private shroud: any, private readonly renderer: any) { }
     get onHoverChange() {
         return this._onHoverChange.asEvent();
@@ -25,12 +35,16 @@ export class MapHoverHandler {
                 entity: undefined,
                 gameObject: undefined,
                 tile: this.currentHoverTile,
+                groundTile: this.currentHoverGroundTile,
+                bridgeTile: this.currentHoverBridgeTile,
             };
         }
         return {
             entity: this.currentHoverEntity,
             gameObject: this.currentHoverEntity?.gameObject,
             tile: this.currentHoverTile,
+            groundTile: this.currentHoverGroundTile,
+            bridgeTile: this.currentHoverBridgeTile,
         };
     }
     setShroud(shroud: any): void {
@@ -54,9 +68,20 @@ export class MapHoverHandler {
             this.needsUpdate = true;
         }
     }
+    // When the pointer is moving (needsUpdate), re-test every frame for snappy
+    // hover. When it is stationary we still re-test periodically so the hover
+    // tracks units moving under the cursor, but at a much lower rate — a full
+    // scene raycast + tile hit-test every frame (~15Hz) is wasteful at idle,
+    // especially in a shroud-free observer/replay view where the target set is
+    // the whole map. 5Hz keeps idle hover correct at ~1/3 the cost.
+    private static readonly IDLE_REFRESH_MS = 1000 / 5;
     private readonly onFrame = (time: number): void => {
-        if (!this.isActive ||
-            (!this.needsUpdate && this.lastUpdate !== undefined && time - this.lastUpdate < 1000 / 15)) {
+        if (!this.isActive) {
+            return;
+        }
+        if (!this.needsUpdate &&
+            this.lastUpdate !== undefined &&
+            time - this.lastUpdate < MapHoverHandler.IDLE_REFRESH_MS) {
             return;
         }
         this.needsUpdate = false;
@@ -69,14 +94,28 @@ export class MapHoverHandler {
         }
         const previousEntity = this.currentHoverEntity;
         const previousTile = this.currentHoverTile;
+        const previousGroundTile = this.currentHoverGroundTile;
+        const previousBridgeTile = this.currentHoverBridgeTile;
+        const groundTile = this.mapTileIntersectHelper.getTileAtScreenPoint(this.lastPointerPos);
+        const bridgeTile = this.getHighBridgeTileAtScreenPoint(this.lastPointerPos);
+        this.currentHoverGroundTile = groundTile;
+        this.currentHoverBridgeTile = bridgeTile;
         const intersection = this.entityIntersectHelper.getEntityAtScreenPoint(this.lastPointerPos);
         if (intersection) {
             this.currentHoverEntity = intersection.renderable;
             let tile: any;
             const gameObject = intersection.renderable.gameObject;
             const foundation = gameObject.getFoundation?.();
-            if (gameObject.isBuilding?.() && foundation && (foundation.width > 1 || foundation.height > 1)) {
-                tile = this.mapTileIntersectHelper.getTileAtScreenPoint(this.lastPointerPos);
+            if (gameObject.isOverlay?.() && gameObject.isBridge?.()) {
+                tile = this.getBridgeTileAtScreenPoint(this.lastPointerPos, gameObject) ??
+                    (gameObject.isHighBridge?.() ? bridgeTile : undefined) ??
+                    gameObject.tile;
+                if (gameObject.isHighBridge?.()) {
+                    this.currentHoverBridgeTile = tile;
+                }
+            }
+            else if (gameObject.isBuilding?.() && foundation && (foundation.width > 1 || foundation.height > 1)) {
+                tile = groundTile;
             }
             else if (gameObject.isTechno?.() && !gameObject.art?.isVoxel) {
                 tile = gameObject.tile;
@@ -99,7 +138,7 @@ export class MapHoverHandler {
         }
         else {
             this.currentHoverEntity = undefined;
-            this.currentHoverTile = this.mapTileIntersectHelper.getTileAtScreenPoint(this.lastPointerPos);
+            this.currentHoverTile = groundTile ?? bridgeTile;
         }
         if (this.shroud &&
             this.currentHoverTile &&
@@ -107,7 +146,10 @@ export class MapHoverHandler {
             !(this.currentHoverEntity?.gameObject?.isOverlay?.() && this.currentHoverEntity?.gameObject?.isBridge?.())) {
             this.currentHoverEntity = undefined;
         }
-        if (this.currentHoverEntity === previousEntity && this.currentHoverTile === previousTile) {
+        if (this.currentHoverEntity === previousEntity &&
+            this.currentHoverTile === previousTile &&
+            this.currentHoverGroundTile === previousGroundTile &&
+            this.currentHoverBridgeTile === previousBridgeTile) {
             return;
         }
         previousEntity?.selectionModel?.setHover(false);
@@ -117,6 +159,8 @@ export class MapHoverHandler {
                 entity: this.currentHoverEntity,
                 gameObject: this.currentHoverEntity?.gameObject,
                 tile: this.currentHoverTile,
+                groundTile: this.currentHoverGroundTile,
+                bridgeTile: this.currentHoverBridgeTile,
             });
         }
     }
@@ -124,6 +168,8 @@ export class MapHoverHandler {
         this.currentHoverEntity?.selectionModel?.setHover(false);
         this.currentHoverEntity = undefined;
         this.currentHoverTile = undefined;
+        this.currentHoverGroundTile = undefined;
+        this.currentHoverBridgeTile = undefined;
         if (this.isActive) {
             this.renderer.onFrame.unsubscribe(this.onFrame);
             this.isActive = false;
@@ -132,5 +178,89 @@ export class MapHoverHandler {
     }
     dispose(): void {
         this.finish();
+    }
+    private getHighBridgeTileAtScreenPoint(pointer: {
+        x: number;
+        y: number;
+    }): any | undefined {
+        const result = this.pickClosestBridgeTileByScreenPoint(this.collectHighBridgeCandidates(pointer), pointer);
+        return result && result.distance <= MapHoverHandler.MAX_BRIDGE_PICK_DISTANCE
+            ? result.tile
+            : undefined;
+    }
+    private getBridgeTileAtScreenPoint(pointer: { x: number; y: number }, bridgeObject: any): any | undefined {
+        const occupiedTiles = this.map.tileOccupation.calculateTilesForGameObject?.(bridgeObject.tile, bridgeObject) ?? [];
+        return this.pickClosestBridgeTileByScreenPoint(occupiedTiles, pointer, bridgeObject)?.tile;
+    }
+    private collectHighBridgeCandidates(pointer: { x: number; y: number }): any[] {
+        const candidates: any[] = [];
+        const seen = new Set<string>();
+        const addTile = (tile: any): void => {
+            if (!tile) {
+                return;
+            }
+            const bridge = this.map.tileOccupation.getBridgeOnTile(tile);
+            if (!bridge?.isHighBridge?.()) {
+                return;
+            }
+            const key = `${tile.rx},${tile.ry}`;
+            if (!seen.has(key)) {
+                seen.add(key);
+                candidates.push(tile);
+            }
+        };
+        const addNearbyTiles = (tile: any, radius: number): void => {
+            if (!tile) {
+                return;
+            }
+            for (let dx = -radius; dx <= radius; dx += 1) {
+                for (let dy = -radius; dy <= radius; dy += 1) {
+                    addTile(this.map.tiles.getByMapCoords(tile.rx + dx, tile.ry + dy));
+                }
+            }
+        };
+        // Sample the cursor across the deck sprite's vertical span (z=0 up to the deck
+        // elevation) so the deck is collected wherever it is visually drawn.
+        for (const elevation of [4, 3, 2, 1]) {
+            for (const tile of this.mapTileIntersectHelper.intersectTilesByScreenPos(pointer, elevation)) {
+                addNearbyTiles(tile, MapHoverHandler.BRIDGE_PICK_RADIUS);
+            }
+        }
+        for (const tile of this.mapTileIntersectHelper.intersectTilesByScreenPos(pointer)) {
+            addNearbyTiles(tile, MapHoverHandler.BRIDGE_PICK_RADIUS);
+        }
+        addNearbyTiles(this.mapTileIntersectHelper.getTileAtScreenPoint(pointer), MapHoverHandler.BRIDGE_PICK_RADIUS);
+        return candidates;
+    }
+    private pickClosestBridgeTileByScreenPoint(tiles: any[], pointer: { x: number; y: number }, bridgeObject?: any): { tile: any; distance: number } | undefined {
+        let closestTile: any;
+        let closestDistance = Number.POSITIVE_INFINITY;
+        const seen = new Set<string>();
+        for (const tile of tiles) {
+            if (!tile) {
+                continue;
+            }
+            const key = `${tile.rx},${tile.ry}`;
+            if (seen.has(key)) {
+                continue;
+            }
+            seen.add(key);
+            const bridge = this.map.tileOccupation.getBridgeOnTile(tile);
+            if (!bridge || (bridgeObject && bridge !== bridgeObject)) {
+                continue;
+            }
+            const screenPoint = this.mapTileIntersectHelper.getTileCenterScreenPoint?.(tile, bridge.tileElevation ?? 0);
+            const distance = screenPoint
+                ? Math.hypot(pointer.x - screenPoint.x, pointer.y - screenPoint.y)
+                : 0;
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closestTile = tile;
+            }
+        }
+        if (!closestTile) {
+            return undefined;
+        }
+        return { tile: closestTile, distance: closestDistance };
     }
 }

--- a/src/gui/screen/game/worldInteraction/WorldInteraction.ts
+++ b/src/gui/screen/game/worldInteraction/WorldInteraction.ts
@@ -338,7 +338,7 @@ export class WorldInteraction {
         const isClick = this.isClickRange(event.pointer);
         let isDoubleSameClick = false;
         const isTouchLongPress = isClick && event.isTouch && event.timeStamp - this.lastMouseDownEvent.timeStamp >= 500;
-        if (event.isTouch) {
+        if (isClick) {
             this.mapHoverHandler.update(event.pointer, true);
         }
         const hover = this.mapHoverHandler.getCurrentHover();

--- a/src/gui/screen/mainMenu/main/TestEntryScreen.ts
+++ b/src/gui/screen/mainMenu/main/TestEntryScreen.ts
@@ -115,6 +115,7 @@ export class TestEntryScreen implements Screen {
             this.createRouteButton('大厅测试', '打开 大厅 测试工具', '/lobbytest'),
             this.createRouteButton('世界测试', '打开 世界场景 测试工具', '/worldscenetest'),
             this.createRouteButton('移动测试', '打开 单位移动 测试工具', '/unitmovementtest'),
+            this.createRouteButton('场景沙盒', '打开 可手动放置单位的地图沙盒', '/scenesandbox'),
             this.createRouteButton('性能测试', '打开 性能 基准 测试工具', '/perftest'),
             this.createBackToCategoriesButton(),
             this.createBackToMenuButton()

--- a/src/tools/SceneSandboxTester.ts
+++ b/src/tools/SceneSandboxTester.ts
@@ -1,0 +1,1909 @@
+import { BoxedVar } from '@/util/BoxedVar';
+import { CompositeDisposable } from '@/util/disposable/CompositeDisposable';
+import { CanvasMetrics } from '@/gui/CanvasMetrics';
+import { Pointer } from '@/gui/Pointer';
+import { UiScene } from '@/gui/UiScene';
+import { GeneralOptions } from '@/gui/screen/options/GeneralOptions';
+import { WorldView } from '@/gui/screen/game/WorldView';
+import { Minimap } from '@/gui/screen/game/component/Minimap';
+import { WorldInteractionFactory } from '@/gui/screen/game/worldInteraction/WorldInteractionFactory';
+import { Engine } from '@/engine/Engine';
+import { IsoCoords } from '@/engine/IsoCoords';
+import { Renderer } from '@/engine/gfx/Renderer';
+import { TheaterType } from '@/engine/TheaterType';
+import { ResourceType } from '@/engine/resourceConfigs';
+import { PointerType } from '@/engine/type/PointerType';
+import { UiAnimationLoop } from '@/engine/UiAnimationLoop';
+import { ConsoleVars } from '@/ConsoleVars';
+import { GameFactory } from '@/game/GameFactory';
+import { Coords } from '@/game/Coords';
+import { Rules } from '@/game/rules/Rules';
+import { OrderActionContext } from '@/game/action/OrderActionContext';
+import { OrderUnitsAction } from '@/game/action/OrderUnitsAction';
+import { OrderFactory } from '@/game/order/OrderFactory';
+import { OrderType } from '@/game/order/OrderType';
+import { TileSets } from '@/game/theater/TileSets';
+import { VxlGeometryPool } from '@/engine/renderable/builder/vxlGeometry/VxlGeometryPool';
+import { VxlGeometryCache } from '@/engine/gfx/geometry/VxlGeometryCache';
+import { ObjectType } from '@/engine/type/ObjectType';
+import { BuildStatus } from '@/game/gameobject/Building';
+import { Infantry } from '@/game/gameobject/Infantry';
+import { VeteranLevel } from '@/game/gameobject/unit/VeteranLevel';
+import { getZoneType, ZoneType } from '@/game/gameobject/unit/ZoneType';
+import { Target } from '@/game/Target';
+import { RadialTileFinder } from '@/game/map/tileFinder/RadialTileFinder';
+import { MapTileIntersectHelper } from '@/engine/util/MapTileIntersectHelper';
+import { MapPanningHelper } from '@/engine/util/MapPanningHelper';
+import { SuperWeaponStatus } from '@/game/SuperWeapon';
+import { SuperWeaponType } from '@/game/type/SuperWeaponType';
+import { SuperWeaponsTrait } from '@/game/trait/SuperWeaponsTrait';
+import { TestToolSupport, type TestToolRuntimeContext } from '@/tools/TestToolSupport';
+
+type StringsLike = {
+    get(key: string): string | undefined;
+    has?(key: string): boolean;
+};
+
+type SceneSandboxOptions = {
+    mapName?: string;
+};
+
+type SpawnKind = 'infantry' | 'vehicle' | 'naval' | 'aircraft' | 'building' | 'superweapon';
+type SpawnOwner = 'local' | 'enemy';
+type HealthPreset = 'full' | 'half' | 'low';
+type TickMultiplier = 1 | 2 | 4 | 8;
+
+type SpawnPreset = {
+    label: string;
+    kind: SpawnKind;
+    name: string;
+};
+
+type SandboxState = {
+    kind: SpawnKind;
+    objectName: string;
+    owner: SpawnOwner;
+    veteranLevel: VeteranLevel;
+    health: HealthPreset;
+    count: number;
+    placementActive: boolean;
+    demolitionActive: boolean;
+    superWeaponTargetingActive: boolean;
+    activeSuperWeaponName: string;
+    panelCollapsed: boolean;
+    tickMultiplier: TickMultiplier;
+    spawnedCount: number;
+    lastMessage: string;
+};
+
+type SandboxRuntime = {
+    game: any;
+    localPlayer: any;
+    enemyPlayer: any;
+    worldScene: any;
+    worldInteraction: any;
+    pointer: Pointer;
+    tileHelper: MapTileIntersectHelper;
+    orderActionContext: OrderActionContext;
+    orderAcceptedSerial: number;
+    catalog: Record<SpawnKind, string[]>;
+    spawnSelect: HTMLSelectElement;
+    superWeaponSelect: HTMLSelectElement;
+    statusEl: HTMLDivElement;
+    strings: StringsLike;
+};
+
+export class SceneSandboxTester {
+    private static disposables = new CompositeDisposable();
+    private static renderer?: Renderer;
+    private static uiAnimationLoop?: UiAnimationLoop;
+    private static gameTickTimer?: number;
+    private static runtime?: SandboxRuntime;
+    private static shiftPlacementActive = false;
+    private static pendingSuperWeaponTile?: any;
+    private static readonly tickMultipliers: TickMultiplier[] = [1, 2, 4, 8];
+    private static readonly bridgePickRadius = 3;
+    private static readonly maxBridgePickDistance = 48;
+    private static readonly superWeaponPointerTypes = new Map<SuperWeaponType, PointerType>()
+        .set(SuperWeaponType.MultiMissile, PointerType.Nuke)
+        .set(SuperWeaponType.LightningStorm, PointerType.Storm)
+        .set(SuperWeaponType.IronCurtain, PointerType.Iron)
+        .set(SuperWeaponType.ChronoSphere, PointerType.Chrono)
+        .set(SuperWeaponType.ChronoWarp, PointerType.Chrono);
+    private static state: SandboxState = {
+        kind: 'vehicle',
+        objectName: '',
+        owner: 'local',
+        veteranLevel: VeteranLevel.None,
+        health: 'full',
+        count: 1,
+        placementActive: false,
+        demolitionActive: false,
+        superWeaponTargetingActive: false,
+        activeSuperWeaponName: '',
+        panelCollapsed: false,
+        tickMultiplier: 2,
+        spawnedCount: 0,
+        lastMessage: '选择单位后点击“进入放置模式”，再在地图上左键放置。',
+    };
+    private static readonly fallbackObjectDisplayNames: Record<string, string> = {
+        E1: '美国大兵',
+        E2: '动员兵',
+        GGI: '重装大兵',
+        ENGINEER: '工程师',
+        SNIPE: '狙击手',
+        TANY: '谭雅',
+        SEAL: '海豹部队',
+        SPY: '间谍',
+        DOG: '警犬',
+        ADOG: '警犬',
+        CLEG: '超时空军团兵',
+        YURI: '尤里',
+        IVAN: '疯狂伊文',
+        FLKT: '防空步兵',
+        TERROR: '恐怖分子',
+        DESO: '辐射工兵',
+        MTNK: '灰熊坦克',
+        HTNK: '犀牛坦克',
+        MGTK: '幻影坦克',
+        SREF: '光棱坦克',
+        FV: '多功能步兵车',
+        TNKD: '坦克杀手',
+        HARV: '矿车',
+        CMIN: '超时空采矿车',
+        AMCV: '盟军机动建设车',
+        SMCV: '苏军机动建设车',
+        PCV: '尤里机动建设车',
+        APOC: '天启坦克',
+        V3: 'V3 火箭车',
+        DRON: '恐怖机器人',
+        HTK: '防空履带车',
+        SAPC: '装甲运兵船',
+        LCRF: '两栖运输艇',
+        DEST: '驱逐舰',
+        AEGIS: '神盾巡洋舰',
+        CARRIER: '航空母舰',
+        DLPH: '海豚',
+        SUB: '台风攻击潜艇',
+        DRED: '无畏级战舰',
+        SQD: '巨型乌贼',
+        ORCA: '入侵者战机',
+        BEAG: '黑鹰战机',
+        ZEP: '基洛夫飞艇',
+        GACNST: '盟军建造厂',
+        NACNST: '苏军建造厂',
+        YACNST: '尤里建造厂',
+        GAPOWR: '盟军发电厂',
+        NAPOWR: '磁能反应炉',
+        YAPOWR: '生化反应炉',
+        GAREFN: '盟军矿石精炼厂',
+        NAREFN: '苏军矿石精炼厂',
+        YAREFN: '奴隶矿场',
+        GAPILE: '盟军兵营',
+        NAHAND: '苏军兵营',
+        YABRCK: '尤里兵营',
+        GAWEAP: '盟军战车工厂',
+        NAWEAP: '苏军战车工厂',
+        YAWEAP: '尤里战车工厂',
+        GAAIRC: '空指部',
+        NARADR: '雷达塔',
+        GAYARD: '盟军船坞',
+        NAYARD: '苏军船坞',
+        YAYARD: '尤里船坞',
+        GATECH: '盟军作战实验室',
+        NATECH: '苏军作战实验室',
+        YATECH: '尤里作战实验室',
+        GACSPH: '超时空传送仪',
+        GAWEAT: '天气控制机',
+        NAIRON: '铁幕装置',
+        NAMISL: '核弹发射井',
+        NAMSLO: '核弹发射井',
+        YAPPET: '心灵控制器',
+        YAGNTC: '基因突变器',
+    };
+
+    static async main(_mixFileLoader: any, gameMapFile: any, parentElement: HTMLElement, strings: StringsLike, context: TestToolRuntimeContext = {}, options: SceneSandboxOptions = {}): Promise<void> {
+        const theaterType = gameMapFile.theaterType ?? TheaterType.Temperate;
+        await TestToolSupport.ensureTheater(theaterType, context.cdnResourceLoader, [
+            ResourceType.UiAlly,
+            ResourceType.Vxl,
+            ResourceType.Anims,
+        ]);
+
+        const viewport = this.getViewport();
+        const host = TestToolSupport.prepareHost(context, viewport.width, viewport.height);
+        host.style.background = '#0f1416';
+        host.style.overflow = 'hidden';
+        parentElement.style.background = '#0f1416';
+
+        const renderer = (this.renderer = new Renderer(viewport.width, viewport.height));
+        renderer.init(host);
+        const canvas = TestToolSupport.placeRendererCanvas(renderer, 0, 0);
+        canvas.dataset.testid = 'scene-sandbox-canvas';
+        canvas.addEventListener('contextmenu', (event) => event.preventDefault());
+        renderer.initStats(document.body);
+        this.disposables.add(renderer);
+
+        const canvasMetrics = new CanvasMetrics(canvas, window);
+        canvasMetrics.init();
+        this.disposables.add(canvasMetrics);
+
+        const generalOptions = new GeneralOptions();
+        generalOptions.rightClickMove.value = true;
+        generalOptions.rightClickScroll.value = false;
+        generalOptions.targetLines.value = true;
+        const runtimeVars = new ConsoleVars();
+        runtimeVars.freeCamera.value = false;
+
+        const pointer = Pointer.factory(
+            Engine.getImages().get('mouse.shp'),
+            Engine.getPalettes().get('mousepal.pal'),
+            renderer,
+            document,
+            canvasMetrics,
+            generalOptions.mouseAcceleration,
+        );
+        pointer.init();
+        pointer.unlock();
+        this.disposables.add(pointer);
+
+        const uiScene = UiScene.factory(viewport);
+        uiScene.add(pointer.getSprite());
+        this.disposables.add(uiScene);
+
+        const theater = await Engine.loadTheater(theaterType);
+        const game = this.createGame(gameMapFile, options.mapName);
+        const localPlayer = game.getPlayerByName('沙盒玩家');
+        const enemyPlayer = game.getPlayerByName('目标方');
+
+        IsoCoords.init({
+            x: 0,
+            y: (game.map.mapBounds.getFullSize().width * Coords.getWorldTileSize()) / 2,
+        });
+        game.init(localPlayer);
+        this.removeBaseUnits(game, localPlayer, enemyPlayer);
+        this.disableSandboxEndConditions(game, localPlayer, enemyPlayer);
+        game.mapShroudTrait.revealMap(localPlayer, game);
+        game.mapShroudTrait.revealMap(enemyPlayer, game);
+        game.start();
+
+        const minimap = new Minimap(game, localPlayer, 0xffd84a, game.rules.general.radar);
+        minimap.setPointerEvents(pointer.pointerEvents);
+        this.disposables.add(minimap);
+        uiScene.add(minimap);
+        this.layoutMinimap(minimap, viewport);
+
+        const silentSound = {
+            getSoundSpec: (key: unknown) => ({
+                name: String(key),
+                volume: 0,
+                minVolume: 0,
+                type: [],
+                control: new Set(),
+                limit: 0,
+                range: 0,
+            }),
+            playWithOptions: () => undefined,
+        };
+
+        const worldView = new WorldView(
+            { width: 0, height: 0 },
+            game,
+            silentSound as any,
+            renderer,
+            runtimeVars,
+            minimap,
+            strings,
+            generalOptions,
+            new VxlGeometryPool(new VxlGeometryCache(null, null)),
+            new Map(),
+        );
+        const worldViewInit = worldView.init(localPlayer, viewport, theater);
+        const worldScene = worldViewInit.worldScene;
+        worldScene.create3DObject?.();
+        this.disposables.add(worldView);
+
+        const keyBinds = {
+            getCommandType() {
+                return undefined;
+            },
+        };
+        const worldInteraction = new WorldInteractionFactory(
+            localPlayer,
+            game,
+            game.unitSelection,
+            worldViewInit.renderableManager,
+            uiScene,
+            worldScene,
+            pointer,
+            renderer,
+            keyBinds,
+            generalOptions,
+            runtimeVars.freeCamera,
+            runtimeVars.debugPaths,
+            true,
+            document,
+            minimap,
+            strings,
+            '#ffd84a',
+            game.debugText,
+            undefined,
+        ).create();
+        worldInteraction.init?.();
+        this.disposables.add(worldInteraction);
+        const orderActionContext = new OrderActionContext();
+        const handleOrder = (event: any) => this.executeLocalOrder(event);
+        worldInteraction.defaultActionHandler.onOrder.subscribe(handleOrder);
+        this.disposables.add(() => worldInteraction.defaultActionHandler.onOrder.unsubscribe(handleOrder));
+
+        renderer.addScene(worldScene);
+        renderer.addScene(uiScene);
+        host.appendChild(uiScene.getHtmlContainer().getElement());
+        this.disposables.add(() => uiScene.getHtmlContainer().getElement().remove());
+
+        const catalog = this.buildCatalog(game.rules, game.art, strings);
+        this.state = {
+            ...this.state,
+            kind: 'vehicle',
+            objectName: this.pickInitialObject(catalog),
+            owner: 'local',
+            veteranLevel: VeteranLevel.None,
+            health: 'full',
+            count: 1,
+            placementActive: false,
+            demolitionActive: false,
+            superWeaponTargetingActive: false,
+            activeSuperWeaponName: '',
+            panelCollapsed: false,
+            tickMultiplier: this.state.tickMultiplier,
+            spawnedCount: 0,
+            lastMessage: `已载入 ${options.mapName ?? '测试地图'}。左侧选择单位后进入放置模式。`,
+        };
+
+        const panel = this.buildControlPanel(host, catalog, options.mapName ?? gameMapFile.name ?? '测试地图');
+        this.disposables.add(() => panel.remove());
+
+        const tileHelper = new MapTileIntersectHelper(game.map, worldScene);
+        const getCanvasPointer = (event: MouseEvent) => canvasMetrics.toCanvasOffset(event.offsetX, event.offsetY);
+        const handleShiftPlacementMouseDown = (event: MouseEvent) => {
+            if (event.button !== 0 || !event.shiftKey || this.isPanelControlEventTarget(event.target)) {
+                return;
+            }
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        };
+        const handleShiftPlacementMouseUp = (event: MouseEvent) => {
+            if (event.button !== 0 || !event.shiftKey || this.isPanelControlEventTarget(event.target)) {
+                return;
+            }
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            const tile = this.getTargetTileAtScreenPoint(getCanvasPointer(event));
+            if (!tile) {
+                this.setStatus('按住 Shift：没有找到可放置的地图格。');
+                return;
+            }
+            const spawnedCount = this.spawnAt(tile);
+            if (spawnedCount > 0) {
+                this.setStatus('按住 Shift：已放置单位，松开 Shift 后恢复正常交互。');
+            }
+        };
+        canvas.addEventListener('mousedown', handleShiftPlacementMouseDown, true);
+        canvas.addEventListener('mouseup', handleShiftPlacementMouseUp, true);
+        this.disposables.add(() => {
+            canvas.removeEventListener('mousedown', handleShiftPlacementMouseDown, true);
+            canvas.removeEventListener('mouseup', handleShiftPlacementMouseUp, true);
+        });
+        this.runtime = {
+            game,
+            localPlayer,
+            enemyPlayer,
+            worldScene,
+            worldInteraction,
+            pointer,
+            tileHelper,
+            orderActionContext,
+            orderAcceptedSerial: 0,
+            catalog,
+            spawnSelect: panel.querySelector('[data-testid="sandbox-object"]') as HTMLSelectElement,
+            superWeaponSelect: panel.querySelector('[data-testid="sandbox-superweapon"]') as HTMLSelectElement,
+            statusEl: panel.querySelector('[data-testid="sandbox-status"]') as HTMLDivElement,
+            strings,
+        };
+        this.syncControls();
+
+        const handlePlacementClick = (event: any) => {
+            if (!this.runtime) {
+                return;
+            }
+            if (this.state.demolitionActive) {
+                if (event.button === 2) {
+                    this.setDemolitionActive(false);
+                    return;
+                }
+                if (event.button !== 0) {
+                    return;
+                }
+                const building = this.findDemolishableBuildingAtScreenPoint(event.pointer);
+                if (!building) {
+                    this.setStatus('拆除失败：当前位置没有可拆除的建筑。');
+                    this.updateDemolitionPointer(event.pointer);
+                    return;
+                }
+                this.demolishBuilding(building);
+                this.updateDemolitionPointer(event.pointer);
+                return;
+            }
+            if (this.state.superWeaponTargetingActive) {
+                if (event.button === 2) {
+                    this.setSuperWeaponTargetingActive(false);
+                    return;
+                }
+                if (event.button !== 0) {
+                    return;
+                }
+                const tile = this.getTargetTileAtScreenPoint(event.pointer);
+                if (!tile) {
+                    this.setStatus('超级武器瞄准失败：没有找到地图格。');
+                    return;
+                }
+                this.triggerSuperWeaponAt(tile);
+                return;
+            }
+            if (!this.state.placementActive) {
+                return;
+            }
+            if (event.button === 2) {
+                this.shiftPlacementActive = false;
+                this.setPlacementActive(false);
+                return;
+            }
+            if (event.button !== 0) {
+                return;
+            }
+            const tile = this.getTargetTileAtScreenPoint(event.pointer);
+            if (!tile) {
+                this.setStatus('没有找到可放置的地图格。');
+                return;
+            }
+            const spawnedCount = this.spawnAt(tile);
+            if (!this.shiftPlacementActive) {
+                this.setPlacementActive(false, spawnedCount > 0
+                    ? '已放置并退出放置模式：当前可直接右键移动/攻击，也可以框选其他单位。'
+                    : '已退出放置模式：可正常选择单位并右键移动/攻击。');
+            }
+            else if (this.shiftPlacementActive && spawnedCount > 0) {
+                this.setStatus('按住 Shift：继续临时放置模式。');
+            }
+        };
+        pointer.pointerEvents.addEventListener('canvas', 'mouseup', handlePlacementClick);
+        this.disposables.add(() => pointer.pointerEvents.removeEventListener('canvas', 'mouseup', handlePlacementClick));
+
+        const handleDemolitionPointerMove = (event: any) => {
+            if (this.state.demolitionActive) {
+                this.updateDemolitionPointer(event.pointer);
+            }
+        };
+        pointer.pointerEvents.addEventListener('canvas', 'mousemove', handleDemolitionPointerMove);
+        this.disposables.add(() => pointer.pointerEvents.removeEventListener('canvas', 'mousemove', handleDemolitionPointerMove));
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (this.handleSandboxShortcut(event)) {
+                return;
+            }
+            if (event.key !== 'Shift' ||
+                event.repeat ||
+                this.state.demolitionActive ||
+                this.state.superWeaponTargetingActive ||
+                this.isPanelControlEventTarget(event.target)) {
+                return;
+            }
+            if (!this.state.placementActive) {
+                this.shiftPlacementActive = true;
+                this.setPlacementActive(true, '按住 Shift：临时放置模式已开启。');
+            }
+        };
+        const handleKeyUp = (event: KeyboardEvent) => {
+            if (event.key !== 'Shift') {
+                return;
+            }
+            if (this.shiftPlacementActive) {
+                this.shiftPlacementActive = false;
+                this.setPlacementActive(false, 'Shift 已松开：恢复正常交互。');
+            }
+        };
+        const handleWindowBlur = () => {
+            if (this.shiftPlacementActive) {
+                this.shiftPlacementActive = false;
+                this.setPlacementActive(false, '窗口失焦：已退出临时放置模式。');
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown, true);
+        document.addEventListener('keyup', handleKeyUp, true);
+        window.addEventListener('blur', handleWindowBlur);
+        this.disposables.add(() => {
+            document.removeEventListener('keydown', handleKeyDown, true);
+            document.removeEventListener('keyup', handleKeyUp, true);
+            window.removeEventListener('blur', handleWindowBlur);
+        });
+
+        this.uiAnimationLoop = new UiAnimationLoop(renderer);
+        this.uiAnimationLoop.start();
+        this.disposables.add(() => this.uiAnimationLoop?.destroy());
+
+        this.gameTickTimer = window.setInterval(() => {
+            try {
+                for (let tick = 0; tick < this.state.tickMultiplier; tick += 1) {
+                    game.update();
+                }
+            }
+            catch (error) {
+                console.error('[SceneSandboxTester] game.update failed', error);
+                this.setStatus(`游戏更新失败：${String(error)}`);
+            }
+        }, 33);
+        this.disposables.add(() => {
+            if (this.gameTickTimer) {
+                clearInterval(this.gameTickTimer);
+                this.gameTickTimer = undefined;
+            }
+        });
+
+        TestToolSupport.setState('scene-sandbox', {
+            mapName: options.mapName ?? gameMapFile.name,
+            theater: TheaterType[theaterType],
+            catalogCounts: {
+                infantry: catalog.infantry.length,
+                vehicle: catalog.vehicle.length,
+                naval: catalog.naval.length,
+                aircraft: catalog.aircraft.length,
+                building: catalog.building.length,
+                superweapon: catalog.superweapon.length,
+            },
+        });
+    }
+
+    private static createGame(gameMapFile: any, mapName?: string): any {
+        const theaterType = gameMapFile.theaterType ?? TheaterType.Temperate;
+        const activeEngine = Engine.getActiveEngine();
+        const theaterSettings = Engine.getTheaterSettings(activeEngine, theaterType);
+        const theaterIni = Engine.getTheaterIni(activeEngine, theaterType);
+        const tileSets = new TileSets(theaterIni);
+        tileSets.loadTileData(Engine.getTileData(), theaterSettings.extension);
+
+        const gameModes = Engine.getMpModes();
+        const gameModeId = gameModes.hasId(0) ? 0 : gameModes.getAll()[0]?.id ?? 0;
+        const baseRules = new Rules(Engine.getRules());
+        const countries = baseRules.getMultiplayerCountries().map((country) => country.name);
+        const colors = [...baseRules.getMultiplayerColors().keys()];
+        const localCountryId = this.findNamedIndex(countries, ['Americans', 'America', 'British']);
+        const enemyCountryId = this.findNamedIndex(countries, ['Russians', 'Russia', 'Confederation']);
+        const localColorId = this.findNamedIndex(colors, ['DarkRed', 'Red', 'Orange']);
+        const enemyColorId = this.findNamedIndex(colors, ['DarkBlue', 'Blue', 'SkyBlue']);
+        const startCount = Math.max(1, gameMapFile.startingLocations?.length ?? 0);
+        const enemyStart = startCount > 1 ? 1 : 0;
+        const timestamp = Date.now();
+        const gameOpts: any = {
+            gameMode: gameModeId,
+            gameSpeed: 5,
+            credits: 100000,
+            unitCount: 0,
+            shortGame: false,
+            superWeapons: true,
+            buildOffAlly: false,
+            mcvRepacks: false,
+            cratesAppear: false,
+            destroyableBridges: true,
+            multiEngineer: false,
+            noDogEngiKills: false,
+            mapName: mapName ?? gameMapFile.name ?? 'scene-sandbox.map',
+            mapTitle: gameMapFile.getOrCreateSection?.('Basic')?.getString?.('Name') ?? '场景沙盒',
+            mapDigest: '',
+            mapSizeBytes: 0,
+            maxSlots: 2,
+            mapOfficial: true,
+            humanPlayers: [
+                { name: '沙盒玩家', countryId: localCountryId, colorId: localColorId, startPos: 0, teamId: 0 },
+                { name: '目标方', countryId: enemyCountryId, colorId: enemyColorId, startPos: enemyStart, teamId: 1 },
+            ],
+            aiPlayers: [],
+        };
+        const modRules = Engine.getIni(gameModes.getById(gameModeId).rulesOverride);
+        return GameFactory.create(
+            gameMapFile,
+            tileSets,
+            Engine.getRules(),
+            Engine.getArt(),
+            Engine.getAi(),
+            modRules,
+            [],
+            'SceneSandbox',
+            timestamp,
+            gameOpts,
+            gameModes as any,
+            true,
+            {},
+            undefined,
+            new BoxedVar(false),
+            new BoxedVar(0),
+        );
+    }
+
+    private static buildCatalog(rules: any, art: any, strings: StringsLike): Record<SpawnKind, string[]> {
+        const fromRules = (rulesMap: Map<string, any>, type: ObjectType) => [...rulesMap.keys()]
+            .filter((name) => {
+                try {
+                    return art.hasObject(name, type);
+                }
+                catch {
+                    return false;
+                }
+            })
+            .sort((left, right) => {
+                const leftLabel = this.resolveObjectDisplayName(rules, strings, type, left);
+                const rightLabel = this.resolveObjectDisplayName(rules, strings, type, right);
+                return leftLabel.localeCompare(rightLabel, 'zh-CN') || left.localeCompare(right);
+            });
+        const vehicles = fromRules(rules.vehicleRules, ObjectType.Vehicle);
+        const naval = vehicles.filter((name) => this.isNavalVehicleRules(rules.getObject(name, ObjectType.Vehicle)));
+        const buildings = fromRules(rules.buildingRules, ObjectType.Building)
+            .filter((name) => !rules.getObject(name, ObjectType.Building).invisibleInGame);
+        const superweapon = buildings.filter((name) => this.isMajorSuperWeaponBuilding(rules, name));
+        return {
+            infantry: fromRules(rules.infantryRules, ObjectType.Infantry),
+            vehicle: vehicles.filter((name) => !naval.includes(name)),
+            naval,
+            aircraft: fromRules(rules.aircraftRules, ObjectType.Aircraft),
+            building: buildings,
+            superweapon,
+        };
+    }
+
+    private static isNavalVehicleRules(rules: any): boolean {
+        return Target.usesGroundLayerUnderBridge({ rules });
+    }
+
+    private static isMajorSuperWeaponBuilding(rules: any, buildingName: string): boolean {
+        const superWeaponName = rules.getObject(buildingName, ObjectType.Building).superWeapon;
+        if (!superWeaponName) {
+            return false;
+        }
+        try {
+            const superWeaponRules = rules.getSuperWeapon(superWeaponName);
+            return [
+                SuperWeaponType.MultiMissile,
+                SuperWeaponType.IronCurtain,
+                SuperWeaponType.LightningStorm,
+                SuperWeaponType.ChronoSphere,
+            ].includes(superWeaponRules.type);
+        }
+        catch {
+            return false;
+        }
+    }
+
+    private static resolveObjectDisplayName(rules: any, strings: StringsLike | undefined, type: ObjectType, name: string): string {
+        try {
+            const objectRules = rules.getObject(name, type) as any;
+            const uiName = objectRules?.uiName;
+            if (typeof uiName === 'string' && uiName.trim()) {
+                const key = uiName.trim();
+                if (/^NOSTR:/i.test(key)) {
+                    return strings?.get(key) || key.replace(/^NOSTR:/i, '');
+                }
+                if (strings?.has?.(key)) {
+                    return strings.get(key) || name;
+                }
+            }
+        }
+        catch {
+            // Fall through to the internal ID when rules are incomplete.
+        }
+        return this.fallbackObjectDisplayNames[name] ?? name;
+    }
+
+    private static pickInitialObject(catalog: Record<SpawnKind, string[]>): string {
+        return catalog.vehicle.find((name) => name === 'MTNK') ??
+            catalog.vehicle[0] ??
+            catalog.naval[0] ??
+            catalog.infantry[0] ??
+            catalog.building[0] ??
+            catalog.superweapon[0] ??
+            catalog.aircraft[0] ??
+            '';
+    }
+
+    private static buildControlPanel(host: HTMLElement, catalog: Record<SpawnKind, string[]>, mapName: string): HTMLDivElement {
+        const panel = document.createElement('div');
+        panel.dataset.testid = 'scene-sandbox-panel';
+        panel.style.cssText = `
+            position: absolute;
+            left: 12px;
+            top: 56px;
+            width: 340px;
+            z-index: 1001;
+            padding: 10px;
+            font: 13px/1.35 Arial, sans-serif;
+            box-sizing: border-box;
+        `;
+
+        const header = document.createElement('div');
+        header.style.cssText = 'display: flex; align-items: center; gap: 6px;';
+        const title = document.createElement('div');
+        title.style.cssText = 'font-weight: bold; font-size: 15px; flex: 1;';
+        title.textContent = '场景沙盒';
+        header.appendChild(title);
+        const homeButton = this.createButton('主页', () => {
+            window.location.hash = '/';
+        });
+        homeButton.dataset.testid = 'sandbox-home';
+        homeButton.style.width = '58px';
+        header.appendChild(homeButton);
+        const collapseButton = this.createButton('收起', () => {
+            this.state.panelCollapsed = !this.state.panelCollapsed;
+            this.syncControls();
+        });
+        collapseButton.dataset.testid = 'sandbox-collapse';
+        collapseButton.style.width = '68px';
+        header.appendChild(collapseButton);
+        panel.appendChild(header);
+
+        const body = document.createElement('div');
+        body.dataset.testid = 'sandbox-panel-body';
+        panel.appendChild(body);
+
+        const mapLine = document.createElement('div');
+        mapLine.style.cssText = 'opacity: 0.9; margin-bottom: 8px;';
+        mapLine.textContent = `地图：${mapName}`;
+        body.appendChild(mapLine);
+
+        const row = (label: string, control: HTMLElement) => {
+            const wrap = document.createElement('label');
+            wrap.style.cssText = 'display: block; margin: 7px 0;';
+            const caption = document.createElement('div');
+            caption.textContent = label;
+            caption.style.cssText = 'margin-bottom: 3px;';
+            wrap.append(caption, control);
+            body.appendChild(wrap);
+        };
+
+        const kindSelect = document.createElement('select');
+        kindSelect.dataset.testid = 'sandbox-kind';
+        kindSelect.style.width = '100%';
+        [
+            ['vehicle', '载具'],
+            ['naval', '船只'],
+            ['infantry', '步兵'],
+            ['aircraft', '飞行器'],
+            ['building', '建筑'],
+            ['superweapon', '超级武器建筑'],
+        ].forEach(([value, label]) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = label;
+            kindSelect.appendChild(option);
+        });
+        kindSelect.value = this.state.kind;
+        kindSelect.onchange = () => {
+            this.state.kind = kindSelect.value as SpawnKind;
+            this.state.objectName = catalog[this.state.kind][0] ?? '';
+            kindSelect.blur();
+            this.syncControls();
+        };
+        row('类型', kindSelect);
+
+        const objectSelect = document.createElement('select');
+        objectSelect.dataset.testid = 'sandbox-object';
+        objectSelect.style.width = '100%';
+        objectSelect.onchange = () => {
+            this.state.objectName = objectSelect.value;
+            objectSelect.blur();
+            this.syncState();
+        };
+        row('对象', objectSelect);
+
+        const ownerSelect = document.createElement('select');
+        ownerSelect.dataset.testid = 'sandbox-owner';
+        ownerSelect.style.width = '100%';
+        [
+            ['local', '沙盒玩家'],
+            ['enemy', '目标方'],
+        ].forEach(([value, label]) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = label;
+            ownerSelect.appendChild(option);
+        });
+        ownerSelect.onchange = () => {
+            this.state.owner = ownerSelect.value as SpawnOwner;
+            ownerSelect.blur();
+            this.syncState();
+        };
+        row('归属', ownerSelect);
+
+        const veteranSelect = document.createElement('select');
+        veteranSelect.dataset.testid = 'sandbox-veteran';
+        veteranSelect.style.width = '100%';
+        [
+            [VeteranLevel.None, '普通'],
+            [VeteranLevel.Veteran, '老兵'],
+            [VeteranLevel.Elite, '精英'],
+        ].forEach(([value, label]) => {
+            const option = document.createElement('option');
+            option.value = String(value);
+            option.textContent = String(label);
+            veteranSelect.appendChild(option);
+        });
+        veteranSelect.onchange = () => {
+            this.state.veteranLevel = Number(veteranSelect.value) as VeteranLevel;
+            veteranSelect.blur();
+            this.syncState();
+        };
+        row('等级', veteranSelect);
+
+        const healthSelect = document.createElement('select');
+        healthSelect.dataset.testid = 'sandbox-health';
+        healthSelect.style.width = '100%';
+        [
+            ['full', '满血'],
+            ['half', '半血'],
+            ['low', '残血'],
+        ].forEach(([value, label]) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = label;
+            healthSelect.appendChild(option);
+        });
+        healthSelect.onchange = () => {
+            this.state.health = healthSelect.value as HealthPreset;
+            healthSelect.blur();
+            this.syncState();
+        };
+        row('血量', healthSelect);
+
+        const countInput = document.createElement('input');
+        countInput.dataset.testid = 'sandbox-count';
+        countInput.type = 'number';
+        countInput.min = '1';
+        countInput.max = '100';
+        countInput.value = String(this.state.count);
+        countInput.style.width = '100%';
+        countInput.onchange = () => {
+            this.state.count = Math.max(1, Math.min(100, Math.floor(Number(countInput.value) || 1)));
+            countInput.value = String(this.state.count);
+            this.syncState();
+        };
+        row('数量', countInput);
+
+        const speedWrap = document.createElement('div');
+        speedWrap.style.cssText = 'display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin: 7px 0;';
+        for (const multiplier of this.tickMultipliers) {
+            const button = this.createButton(`${multiplier}x`, () => {
+                this.state.tickMultiplier = multiplier;
+                this.setStatus(`速度倍率已切换为 ${multiplier}x。`);
+                this.syncControls();
+            });
+            button.dataset.testid = 'sandbox-speed';
+            button.dataset.speed = String(multiplier);
+            speedWrap.appendChild(button);
+        }
+        row('速度', speedWrap);
+
+        const actions = document.createElement('div');
+        actions.style.cssText = 'display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 8px;';
+        const placeButton = this.createButton('进入放置模式（Shift）', () => this.setPlacementActive(!this.state.placementActive));
+        placeButton.dataset.testid = 'sandbox-place';
+        const demolitionButton = this.createButton('拆除建筑（C）', () => this.setDemolitionActive(!this.state.demolitionActive));
+        demolitionButton.dataset.testid = 'sandbox-demolish';
+        const clearButton = this.createButton('清空生成物', () => this.clearSpawnedObjects());
+        clearButton.dataset.testid = 'sandbox-clear';
+        clearButton.style.gridColumn = '1 / -1';
+        actions.append(placeButton, demolitionButton, clearButton);
+        body.appendChild(actions);
+
+        const superWeaponSelect = document.createElement('select');
+        superWeaponSelect.dataset.testid = 'sandbox-superweapon';
+        superWeaponSelect.style.width = '100%';
+        superWeaponSelect.onchange = () => {
+            this.state.activeSuperWeaponName = superWeaponSelect.value;
+            this.updateSuperWeaponPointer();
+            superWeaponSelect.blur();
+            this.syncState();
+        };
+        row('已拥有超级武器', superWeaponSelect);
+
+        const superWeaponButton = this.createButton('触发超级武器（W）', () => {
+            this.setSuperWeaponTargetingActive(!this.state.superWeaponTargetingActive);
+        });
+        superWeaponButton.dataset.testid = 'sandbox-fire-superweapon';
+        superWeaponButton.style.marginTop = '2px';
+        body.appendChild(superWeaponButton);
+
+        const quickWrap = document.createElement('div');
+        quickWrap.style.cssText = 'display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 8px;';
+        this.getQuickPresets(catalog).forEach((preset) => {
+            const button = this.createButton(preset.label, () => {
+                this.state.kind = preset.kind;
+                this.state.objectName = preset.name;
+                this.syncControls();
+            });
+            button.dataset.quickKind = preset.kind;
+            quickWrap.appendChild(button);
+        });
+        body.appendChild(quickWrap);
+
+        const status = document.createElement('div');
+        status.dataset.testid = 'sandbox-status';
+        status.style.cssText = 'margin-top: 9px; white-space: pre-wrap; min-height: 38px;';
+        body.appendChild(status);
+
+        TestToolSupport.applyPanelTheme(panel);
+        this.applyQuickPresetButtonTheme(panel);
+        host.appendChild(panel);
+        return panel;
+    }
+
+    private static createButton(label: string, onClick: () => void): HTMLButtonElement {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = label;
+        button.style.width = '100%';
+        button.onclick = onClick;
+        return button;
+    }
+
+    private static isPanelControlEventTarget(target: EventTarget | null): boolean {
+        return !!(target as HTMLElement | null)?.closest?.('[data-testid="scene-sandbox-panel"] input, [data-testid="scene-sandbox-panel"] select, [data-testid="scene-sandbox-panel"] textarea, [contenteditable="true"]');
+    }
+
+    private static isTextEditingEventTarget(target: EventTarget | null): boolean {
+        const element = target as HTMLElement | null;
+        return !!element?.closest?.('input, textarea, [contenteditable="true"]');
+    }
+
+    private static applyQuickPresetButtonTheme(panel: HTMLElement): void {
+        const themedButtons = [
+            {
+                kind: 'building',
+                background: 'linear-gradient(180deg, #17633d, #0a3324)',
+                border: '#39d482',
+                color: '#e8fff0',
+            },
+            {
+                kind: 'superweapon',
+                background: 'linear-gradient(180deg, #4b2877, #25103f)',
+                border: '#ba8cff',
+                color: '#f4eaff',
+            },
+        ];
+        for (const theme of themedButtons) {
+            const button = panel.querySelector(`[data-quick-kind="${theme.kind}"]`) as HTMLButtonElement | null;
+            if (!button) {
+                continue;
+            }
+            button.style.background = theme.background;
+            button.style.borderColor = theme.border;
+            button.style.color = theme.color;
+            button.style.boxShadow = `inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 0 0 1px ${theme.border}33`;
+        }
+    }
+
+    private static getQuickPresets(catalog: Record<SpawnKind, string[]>): SpawnPreset[] {
+        const pick = (kind: SpawnKind, names: string[]) => names.find((name) => catalog[kind].includes(name)) ?? catalog[kind][0];
+        const presets: SpawnPreset[] = [
+            { label: '基础步兵', kind: 'infantry', name: pick('infantry', ['E1', 'GGI', 'ENGINEER']) },
+            { label: '主战坦克', kind: 'vehicle', name: pick('vehicle', ['MTNK', 'HTNK', 'APOC']) },
+            { label: '船只', kind: 'naval', name: pick('naval', ['LCRF', 'SAPC', 'DEST']) },
+            { label: '飞行器', kind: 'aircraft', name: pick('aircraft', ['ORCA', 'BEAG', 'ZEP']) },
+            { label: '基础建筑', kind: 'building', name: pick('building', ['GAPOWR', 'NAPOWR', 'GAREFN', 'GAWEAP']) },
+            { label: '超级武器', kind: 'superweapon', name: pick('superweapon', ['NAMISL', 'NAMSLO', 'NAIRON', 'GACSPH', 'GAWEAT', 'YAPPET']) },
+        ];
+        return presets.filter((preset) => !!preset.name);
+    }
+
+    private static syncControls(): void {
+        const runtime = this.runtime;
+        const panel = document.querySelector('[data-testid="scene-sandbox-panel"]') as HTMLDivElement | null;
+        if (!panel) {
+            return;
+        }
+        const kindSelect = panel.querySelector('[data-testid="sandbox-kind"]') as HTMLSelectElement;
+        const objectSelect = panel.querySelector('[data-testid="sandbox-object"]') as HTMLSelectElement;
+        const ownerSelect = panel.querySelector('[data-testid="sandbox-owner"]') as HTMLSelectElement;
+        const veteranSelect = panel.querySelector('[data-testid="sandbox-veteran"]') as HTMLSelectElement;
+        const healthSelect = panel.querySelector('[data-testid="sandbox-health"]') as HTMLSelectElement;
+        const countInput = panel.querySelector('[data-testid="sandbox-count"]') as HTMLInputElement;
+        const placeButton = panel.querySelector('[data-testid="sandbox-place"]') as HTMLButtonElement;
+        const demolitionButton = panel.querySelector('[data-testid="sandbox-demolish"]') as HTMLButtonElement;
+        const superWeaponSelect = panel.querySelector('[data-testid="sandbox-superweapon"]') as HTMLSelectElement;
+        const superWeaponButton = panel.querySelector('[data-testid="sandbox-fire-superweapon"]') as HTMLButtonElement;
+        const collapseButton = panel.querySelector('[data-testid="sandbox-collapse"]') as HTMLButtonElement;
+        const body = panel.querySelector('[data-testid="sandbox-panel-body"]') as HTMLDivElement;
+        const speedButtons = [...panel.querySelectorAll('[data-testid="sandbox-speed"]')] as HTMLButtonElement[];
+
+        const catalog = runtime?.catalog ?? {
+            infantry: [],
+            vehicle: [],
+            naval: [],
+            aircraft: [],
+            building: [],
+            superweapon: [],
+        };
+        if (!catalog[this.state.kind].includes(this.state.objectName)) {
+            this.state.objectName = catalog[this.state.kind][0] ?? '';
+        }
+        kindSelect.value = this.state.kind;
+        objectSelect.replaceChildren();
+        for (const name of catalog[this.state.kind]) {
+            const option = document.createElement('option');
+            option.value = name;
+            option.textContent = this.getObjectOptionLabel(this.state.kind, name);
+            option.title = name;
+            option.selected = name === this.state.objectName;
+            objectSelect.appendChild(option);
+        }
+        ownerSelect.value = this.state.owner;
+        veteranSelect.value = String(this.state.veteranLevel);
+        healthSelect.value = this.state.health;
+        countInput.value = String(this.state.count);
+        placeButton.textContent = this.state.placementActive ? '退出放置模式（Shift）' : '进入放置模式（Shift）';
+        demolitionButton.textContent = this.state.demolitionActive ? '退出拆除建筑（C）' : '拆除建筑（C）';
+        demolitionButton.style.outline = this.state.demolitionActive ? '2px solid #ffd84a' : '';
+        const superWeapons = this.getAvailableSuperWeapons();
+        if (!superWeapons.some((superWeapon) => superWeapon.name === this.state.activeSuperWeaponName)) {
+            this.state.activeSuperWeaponName = superWeapons[0]?.name ?? '';
+        }
+        superWeaponSelect.replaceChildren();
+        for (const superWeapon of superWeapons) {
+            const option = document.createElement('option');
+            option.value = superWeapon.name;
+            option.textContent = this.getSuperWeaponLabel(superWeapon);
+            option.selected = superWeapon.name === this.state.activeSuperWeaponName;
+            superWeaponSelect.appendChild(option);
+        }
+        superWeaponSelect.disabled = !superWeapons.length;
+        superWeaponButton.disabled = !superWeapons.length;
+        superWeaponButton.textContent = this.state.superWeaponTargetingActive ? '取消超级武器（W）' : '触发超级武器（W）';
+        collapseButton.textContent = this.state.panelCollapsed ? '展开' : '收起';
+        body.style.display = this.state.panelCollapsed ? 'none' : 'block';
+        panel.style.width = this.state.panelCollapsed ? '214px' : '340px';
+        for (const button of speedButtons) {
+            const active = Number(button.dataset.speed) === this.state.tickMultiplier;
+            button.style.fontWeight = active ? 'bold' : 'normal';
+            button.style.outline = active ? '2px solid #ffd84a' : '';
+        }
+        this.updateStatus();
+        this.syncState();
+    }
+
+    private static getObjectOptionLabel(kind: SpawnKind, name: string): string {
+        const runtime = this.runtime;
+        const type = this.objectTypeForKind(kind);
+        const displayName = runtime
+            ? this.resolveObjectDisplayName(runtime.game.rules, runtime.strings, type, name)
+            : this.fallbackObjectDisplayNames[name] ?? name;
+        return displayName === name ? name : `${displayName}（${name}）`;
+    }
+
+    private static getAvailableSuperWeapons(): any[] {
+        return (this.runtime?.localPlayer?.superWeaponsTrait?.getAll?.() ?? [])
+            .filter((superWeapon: any) => this.superWeaponPointerTypes.has(superWeapon.rules?.type));
+    }
+
+    private static getSuperWeaponLabel(superWeapon: any): string {
+        const typeName = superWeapon.rules?.type !== undefined
+            ? SuperWeaponType[superWeapon.rules.type] ?? String(superWeapon.rules.type)
+            : 'Unknown';
+        const statusLabel = superWeapon.status === SuperWeaponStatus.Ready
+            ? '就绪'
+            : superWeapon.status === SuperWeaponStatus.Paused
+                ? '暂停'
+                : '充能';
+        return `${this.getSuperWeaponDisplayName(superWeapon.name)}（${typeName}，${statusLabel}）`;
+    }
+
+    private static getSuperWeaponDisplayName(name: string): string {
+        const labels: Record<string, string> = {
+            NukeSpecial: '核弹',
+            IronCurtainSpecial: '铁幕',
+            ChronoSphereSpecial: '超时空传送',
+            LightningStormSpecial: '闪电风暴',
+            PsychicDominatorSpecial: '心灵控制器',
+            GeneticConverterSpecial: '基因突变器',
+            ParaDropSpecial: '伞兵',
+            AmerParaDropSpecial: '美国伞兵',
+        };
+        return labels[name] ?? name;
+    }
+
+    private static getActiveSuperWeapon(): any | undefined {
+        const superWeapons = this.getAvailableSuperWeapons();
+        return superWeapons.find((superWeapon) => superWeapon.name === this.state.activeSuperWeaponName) ?? superWeapons[0];
+    }
+
+    private static makeSuperWeaponReady(superWeapon: any): void {
+        superWeapon.status = SuperWeaponStatus.Ready;
+        superWeapon.chargeTicks = 0;
+    }
+
+    private static getSuperWeaponPointerType(superWeapon: any | undefined): PointerType {
+        const type = superWeapon?.rules?.type;
+        return type !== undefined
+            ? this.superWeaponPointerTypes.get(type) ?? PointerType.Default
+            : PointerType.Default;
+    }
+
+    private static updateSuperWeaponPointer(): void {
+        if (this.state.superWeaponTargetingActive) {
+            this.runtime?.pointer?.setPointerType(this.getSuperWeaponPointerType(this.getActiveSuperWeapon()));
+        }
+    }
+
+    private static triggerSuperWeaponAt(tile: any): void {
+        const runtime = this.runtime;
+        const superWeapon = this.getActiveSuperWeapon();
+        if (!runtime || !superWeapon) {
+            this.setSuperWeaponTargetingActive(false, '没有可触发的超级武器。');
+            return;
+        }
+        const rules = superWeapon.rules;
+        if (rules?.type === undefined) {
+            this.setSuperWeaponTargetingActive(false, `超级武器 ${superWeapon.name} 缺少 Type，无法触发。`);
+            return;
+        }
+        if (rules.preClick && !this.pendingSuperWeaponTile) {
+            this.pendingSuperWeaponTile = tile;
+            this.setStatus(`已选择第一个目标 @ ${tile.rx},${tile.ry}，请再左键选择第二个目标。`);
+            return;
+        }
+        const tile1 = this.pendingSuperWeaponTile ?? tile;
+        const tile2 = this.pendingSuperWeaponTile ? tile : undefined;
+        this.pendingSuperWeaponTile = undefined;
+        this.makeSuperWeaponReady(superWeapon);
+        runtime.game.traits
+            .get(SuperWeaponsTrait)
+            .activateSuperWeapon(rules.type, runtime.localPlayer, runtime.game, tile1, tile2);
+        this.setSuperWeaponTargetingActive(false, `已触发 ${this.getSuperWeaponDisplayName(superWeapon.name)} @ ${tile1.rx},${tile1.ry}${tile2 ? ` -> ${tile2.rx},${tile2.ry}` : ''}。`);
+    }
+
+    private static handleSandboxShortcut(event: KeyboardEvent): boolean {
+        if (event.repeat ||
+            event.ctrlKey ||
+            event.altKey ||
+            event.metaKey ||
+            this.isTextEditingEventTarget(event.target)) {
+            return false;
+        }
+        if (event.key === 'Escape' && (this.state.placementActive || this.state.demolitionActive || this.state.superWeaponTargetingActive)) {
+            event.preventDefault();
+            event.stopPropagation();
+            this.shiftPlacementActive = false;
+            this.state.placementActive = false;
+            this.state.demolitionActive = false;
+            this.setSuperWeaponTargetingActive(false, '已取消当前临时模式。');
+            return true;
+        }
+        const key = event.key.toLowerCase();
+        const orderByKey = new Map<string, OrderType>([
+            ['s', OrderType.Stop],
+            ['g', OrderType.Guard],
+            ['d', OrderType.DeploySelected],
+            ['x', OrderType.Scatter],
+        ]);
+        if (key === 'h') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.centerOnHome();
+            return true;
+        }
+        if (key === 'p') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.runtime?.worldInteraction?.unitSelectionHandler?.selectCombatants?.();
+            this.setStatus('已选择本方战斗单位。');
+            return true;
+        }
+        if (key === 'w') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.setSuperWeaponTargetingActive(!this.state.superWeaponTargetingActive);
+            return true;
+        }
+        if (key === 'c') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.setDemolitionActive(!this.state.demolitionActive);
+            return true;
+        }
+        const orderType = orderByKey.get(key);
+        if (orderType !== undefined) {
+            event.preventDefault();
+            event.stopPropagation();
+            this.executeKeyboardOrder(orderType);
+            return true;
+        }
+        return false;
+    }
+
+    private static executeKeyboardOrder(orderType: OrderType): void {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return;
+        }
+        const selectedUnits = runtime.game.unitSelection
+            .getSelectedUnits()
+            .filter((unit: any) => unit.owner === runtime.localPlayer && !unit.rules.spawned);
+        if (!selectedUnits.length) {
+            this.setStatus(`${OrderType[orderType]} 未执行：没有选中的本方单位。`);
+            return;
+        }
+        runtime.orderActionContext
+            .getOrCreateSelection(runtime.localPlayer)
+            .update(selectedUnits);
+        const action = new OrderUnitsAction(
+            runtime.game,
+            runtime.game.map,
+            runtime.orderActionContext,
+            new OrderFactory(runtime.game, runtime.game.map),
+        );
+        action.player = runtime.localPlayer;
+        action.orderType = orderType;
+        action.target = undefined;
+        action.process();
+        runtime.orderAcceptedSerial += 1;
+        this.setStatus(`已执行快捷键命令：${OrderType[orderType]}。`);
+    }
+
+    private static centerOnHome(): void {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return;
+        }
+        const tile = this.findHomeTile();
+        if (!tile) {
+            this.setStatus('H 回基地失败：没有找到本方建筑或单位。');
+            return;
+        }
+        const mapPanningHelper = new MapPanningHelper(runtime.game.map);
+        runtime.worldScene.cameraPan.setPan(mapPanningHelper.computeCameraPanFromTile(tile.rx, tile.ry));
+        this.setStatus(`已回到基地视角 @ ${tile.rx},${tile.ry}。`);
+    }
+
+    private static findHomeTile(): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        const owned = runtime.localPlayer.getOwnedObjects?.() ?? [];
+        const building = owned.find((obj: any) => obj.isBuilding?.() && obj.tile);
+        if (building) {
+            return building.tile;
+        }
+        const baseUnit = owned.find((obj: any) => obj.isUnit?.() && runtime.game.rules.general.baseUnit.includes(obj.name));
+        if (baseUnit) {
+            return baseUnit.tile;
+        }
+        const ownedObjectTile = owned.find((obj: any) => obj.tile)?.tile;
+        if (ownedObjectTile) {
+            return ownedObjectTile;
+        }
+        const startLocation = runtime.game.map.startingLocations?.[runtime.localPlayer.startLocation];
+        return startLocation
+            ? runtime.game.map.tiles.getByMapCoords(startLocation.x, startLocation.y)
+            : undefined;
+    }
+
+    private static setPlacementActive(active: boolean, message?: string): void {
+        if (active) {
+            this.state.demolitionActive = false;
+            this.state.superWeaponTargetingActive = false;
+            this.pendingSuperWeaponTile = undefined;
+            this.runtime?.pointer?.setPointerType(PointerType.Default);
+        }
+        this.state.placementActive = active;
+        this.updateWorldInteractionEnabled();
+        this.setStatus(message ?? (active
+            ? '放置模式已开启：在地图上左键放置，右键/按钮退出。'
+            : '放置模式已关闭：可正常选择单位并右键移动/攻击。'));
+        this.syncControls();
+    }
+
+    private static setSuperWeaponTargetingActive(active: boolean, message?: string): void {
+        const available = this.getAvailableSuperWeapons();
+        if (active && !available.length) {
+            this.setStatus('没有可触发的超级武器：先放置一个超级武器建筑。');
+            this.syncControls();
+            return;
+        }
+        if (active) {
+            this.state.placementActive = false;
+            this.shiftPlacementActive = false;
+            this.state.demolitionActive = false;
+        }
+        this.state.superWeaponTargetingActive = active;
+        this.pendingSuperWeaponTile = undefined;
+        this.updateWorldInteractionEnabled();
+        if (active) {
+            this.updateSuperWeaponPointer();
+        }
+        else {
+            this.runtime?.pointer?.setPointerType(PointerType.Default);
+        }
+        this.setStatus(message ?? (active
+            ? '超级武器瞄准：左键选择目标，右键取消。'
+            : '已退出超级武器瞄准。'));
+        this.syncControls();
+    }
+
+    private static setDemolitionActive(active: boolean, message?: string): void {
+        if (active) {
+            this.state.placementActive = false;
+            this.state.superWeaponTargetingActive = false;
+            this.shiftPlacementActive = false;
+            this.pendingSuperWeaponTile = undefined;
+        }
+        this.state.demolitionActive = active;
+        this.updateWorldInteractionEnabled();
+        if (active) {
+            this.updateDemolitionPointer(this.runtime?.pointer?.getPosition?.());
+        }
+        else {
+            this.runtime?.pointer?.setPointerType(PointerType.Default);
+        }
+        this.setStatus(message ?? (active
+            ? '拆除建筑模式已开启：左键点击建筑触发拆除动画，右键/Esc 退出。'
+            : '拆除建筑模式已关闭。'));
+        this.syncControls();
+    }
+
+    private static updateWorldInteractionEnabled(): void {
+        this.runtime?.worldInteraction?.setEnabled?.(!this.state.placementActive && !this.state.demolitionActive && !this.state.superWeaponTargetingActive);
+    }
+
+    private static getTargetTileAtScreenPoint(pointer: { x: number; y: number }): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        return this.getHighBridgeTileAtScreenPoint(pointer) ??
+            runtime.tileHelper.getTileAtScreenPoint(pointer);
+    }
+
+    private static getHighBridgeTileAtScreenPoint(pointer: { x: number; y: number }): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        const result = this.pickClosestBridgeTileByScreenPoint(this.collectHighBridgeCandidates(pointer), pointer);
+        return result && result.distance <= this.maxBridgePickDistance
+            ? result.tile
+            : undefined;
+    }
+
+    private static collectHighBridgeCandidates(pointer: { x: number; y: number }): any[] {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return [];
+        }
+        const candidates: any[] = [];
+        const seen = new Set<string>();
+        const addTile = (tile: any): void => {
+            if (!tile) {
+                return;
+            }
+            const bridge = runtime.game.map.tileOccupation.getBridgeOnTile(tile);
+            if (!bridge?.isHighBridge?.()) {
+                return;
+            }
+            const key = `${tile.rx},${tile.ry}`;
+            if (!seen.has(key)) {
+                seen.add(key);
+                candidates.push(tile);
+            }
+        };
+        const addNearbyTiles = (tile: any, radius: number): void => {
+            if (!tile) {
+                return;
+            }
+            for (let dx = -radius; dx <= radius; dx += 1) {
+                for (let dy = -radius; dy <= radius; dy += 1) {
+                    addTile(runtime.game.map.tiles.getByMapCoords(tile.rx + dx, tile.ry + dy));
+                }
+            }
+        };
+        for (const tile of runtime.tileHelper.intersectTilesByScreenPos(pointer, 4)) {
+            addNearbyTiles(tile, 1);
+        }
+        for (const tile of runtime.tileHelper.intersectTilesByScreenPos(pointer)) {
+            addNearbyTiles(tile, this.bridgePickRadius);
+        }
+        addNearbyTiles(runtime.tileHelper.getTileAtScreenPoint(pointer), this.bridgePickRadius);
+        return candidates;
+    }
+
+    private static pickClosestBridgeTileByScreenPoint(tiles: any[], pointer: { x: number; y: number }): { tile: any; distance: number } | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        let closestTile: any;
+        let closestDistance = Number.POSITIVE_INFINITY;
+        const seen = new Set<string>();
+        for (const tile of tiles) {
+            if (!tile) {
+                continue;
+            }
+            const key = `${tile.rx},${tile.ry}`;
+            if (seen.has(key)) {
+                continue;
+            }
+            seen.add(key);
+            const bridge = runtime.game.map.tileOccupation.getBridgeOnTile(tile);
+            if (!bridge) {
+                continue;
+            }
+            const screenPoint = runtime.tileHelper.getTileCenterScreenPoint?.(tile, bridge.tileElevation ?? 0) ??
+                this.getTileCenterScreenPoint(tile, bridge.tileElevation ?? 0);
+            const distance = Math.hypot(pointer.x - screenPoint.x, pointer.y - screenPoint.y);
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closestTile = tile;
+            }
+        }
+        if (!closestTile) {
+            return undefined;
+        }
+        return { tile: closestTile, distance: closestDistance };
+    }
+
+    private static getTileCenterScreenPoint(tile: any, tileElevation: number): { x: number; y: number } {
+        const runtime = this.runtime!;
+        const viewport = runtime.worldScene.viewport;
+        const origin = IsoCoords.worldToScreen(0, 0);
+        const pan = runtime.worldScene.cameraPan.getPan();
+        const screenPos = IsoCoords.tile3dToScreen(tile.rx + 0.5, tile.ry + 0.5, tile.z + tileElevation);
+        return {
+            x: screenPos.x - origin.x - pan.x + viewport.x + viewport.width / 2,
+            y: screenPos.y - origin.y - pan.y + viewport.y + viewport.height / 2,
+        };
+    }
+
+    private static updateDemolitionPointer(pointer: { x: number; y: number } | undefined): void {
+        const runtime = this.runtime;
+        if (!runtime || !this.state.demolitionActive) {
+            return;
+        }
+        const building = pointer ? this.findDemolishableBuildingAtScreenPoint(pointer) : undefined;
+        runtime.pointer.setPointerType(building ? PointerType.Sell : PointerType.NoSell);
+    }
+
+    private static findDemolishableBuildingAtScreenPoint(pointer: { x: number; y: number }): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        const tiles = [
+            runtime.tileHelper.getTileAtScreenPoint(pointer),
+            this.getHighBridgeTileAtScreenPoint(pointer),
+        ].filter((tile, index, all): tile is any => !!tile && all.indexOf(tile) === index);
+        for (const tile of tiles) {
+            const building = runtime.game.map
+                .getObjectsOnTile(tile)
+                .find((obj: any) => this.canDemolishBuilding(obj));
+            if (building) {
+                return building;
+            }
+        }
+        return undefined;
+    }
+
+    private static canDemolishBuilding(obj: any): boolean {
+        const runtime = this.runtime;
+        return !!(runtime &&
+            obj?.isBuilding?.() &&
+            obj.isSpawned &&
+            !obj.isDestroyed &&
+            !obj.isCrashing &&
+            obj.buildStatus !== BuildStatus.BuildDown &&
+            !obj.rules?.invisibleInGame &&
+            (obj.owner === runtime.localPlayer || obj.owner === runtime.enemyPlayer));
+    }
+
+    private static demolishBuilding(building: any): void {
+        const runtime = this.runtime;
+        if (!runtime || !this.canDemolishBuilding(building)) {
+            this.setStatus('拆除失败：目标不是可拆除建筑。');
+            return;
+        }
+        const objectLabel = this.resolveObjectDisplayName(runtime.game.rules, runtime.strings, ObjectType.Building, building.name);
+        try {
+            const worker = runtime.game.getConstructionWorker(building.owner);
+            worker.unplace(building, () => {
+                building.dispose?.();
+                this.state.spawnedCount = Math.max(0, this.state.spawnedCount - 1);
+                this.keepSandboxPlayersActive(runtime.game, runtime.localPlayer, runtime.enemyPlayer);
+                this.setStatus(`已完成拆除 ${objectLabel}（${building.name}）。`);
+                this.syncControls();
+            });
+            this.setStatus(`正在拆除 ${objectLabel}（${building.name}）：请观察 BuildDown 动画。`);
+        }
+        catch (error) {
+            console.error('[SceneSandboxTester] Failed to demolish building', error);
+            this.setStatus(`拆除建筑失败：${String(error)}`);
+        }
+    }
+
+    private static executeLocalOrder(event: { orderType: number; target: any; feedbackType?: unknown }): void {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return;
+        }
+        const selectedUnits = runtime.game.unitSelection
+            .getSelectedUnits()
+            .filter((unit: any) => unit.owner === runtime.localPlayer && !unit.rules.spawned);
+        if (!selectedUnits.length) {
+            return;
+        }
+        try {
+            runtime.orderActionContext
+                .getOrCreateSelection(runtime.localPlayer)
+                .update(selectedUnits);
+            const action = new OrderUnitsAction(
+                runtime.game,
+                runtime.game.map,
+                runtime.orderActionContext,
+                new OrderFactory(runtime.game, runtime.game.map),
+            );
+            action.player = runtime.localPlayer;
+            action.orderType = event.orderType;
+            action.target = event.target;
+            action.process();
+            const acceptedUnits = selectedUnits.filter((unit: any) => !unit.unitOrderTrait?.isIdle?.());
+            if (acceptedUnits.length) {
+                runtime.orderAcceptedSerial += 1;
+                this.setStatus(`已向 ${acceptedUnits.length} 个单位下达命令。`);
+            }
+            else {
+                this.setStatus(`命令未被接受：当前选中 ${selectedUnits.length} 个本方单位。`);
+            }
+        }
+        catch (error) {
+            console.error('[SceneSandboxTester] Failed to execute local order', error);
+            this.setStatus(`下达命令失败：${String(error)}`);
+        }
+    }
+
+    private static spawnAt(targetTile: any): number {
+        const runtime = this.runtime;
+        if (!runtime || !this.state.objectName) {
+            return 0;
+        }
+        const objectType = this.objectTypeForKind(this.state.kind);
+        if (objectType === ObjectType.Building) {
+            return this.spawnBuildingAt(targetTile);
+        }
+        const owner = this.state.owner === 'local' ? runtime.localPlayer : runtime.enemyPlayer;
+        this.keepSandboxPlayersActive(runtime.game, runtime.localPlayer, runtime.enemyPlayer);
+        const unitRules = runtime.game.rules.getObject(this.state.objectName, objectType);
+        const objectLabel = this.resolveObjectDisplayName(runtime.game.rules, runtime.strings, objectType, this.state.objectName);
+        const spawned: any[] = [];
+        for (let index = 0; index < this.state.count; index += 1) {
+            const unit = runtime.game.createUnitForPlayer(unitRules, owner);
+            const tile = this.findSpawnTile(targetTile, unit, spawned.length);
+            if (!tile) {
+                unit.dispose?.();
+                this.setStatus(`无法在 ${targetTile.rx},${targetTile.ry} 附近找到可放置位置。已生成 ${spawned.length}/${this.state.count}。`);
+                break;
+            }
+            if (unit.isInfantry?.()) {
+                unit.position.subCell = Infantry.SUB_CELLS[index % Infantry.SUB_CELLS.length];
+            }
+            this.applySpawnLayer(unit, tile);
+            runtime.game.spawnObject(unit, tile);
+            this.applySpawnState(unit);
+            spawned.push(unit);
+        }
+        if (spawned.length && owner === runtime.localPlayer) {
+            runtime.game.unitSelection.deselectAll();
+            spawned.forEach((unit) => runtime.game.unitSelection.addToSelection(unit));
+        }
+        this.state.spawnedCount += spawned.length;
+        this.setStatus(`已生成 ${spawned.length} 个 ${objectLabel}（${this.state.objectName}）@ ${targetTile.rx},${targetTile.ry}。`);
+        this.keepSandboxPlayersActive(runtime.game, runtime.localPlayer, runtime.enemyPlayer);
+        return spawned.length;
+    }
+
+    private static spawnBuildingAt(targetTile: any): number {
+        const runtime = this.runtime;
+        if (!runtime || !this.state.objectName) {
+            return 0;
+        }
+        const owner = this.state.owner === 'local' ? runtime.localPlayer : runtime.enemyPlayer;
+        this.keepSandboxPlayersActive(runtime.game, runtime.localPlayer, runtime.enemyPlayer);
+        const worker = runtime.game.getConstructionWorker(owner);
+        const buildingRules = runtime.game.rules.getObject(this.state.objectName, ObjectType.Building);
+        const objectLabel = this.resolveObjectDisplayName(runtime.game.rules, runtime.strings, ObjectType.Building, this.state.objectName);
+        const spawned: any[] = [];
+        for (let index = 0; index < this.state.count; index += 1) {
+            const tile = this.findBuildingSpawnTile(targetTile, worker, this.state.objectName, spawned.length);
+            if (!tile) {
+                this.setStatus(`无法在 ${targetTile.rx},${targetTile.ry} 附近找到可放置建筑的位置。已生成 ${spawned.length}/${this.state.count}。`);
+                break;
+            }
+            const placedBuildings = worker.placeAt(buildingRules.name, tile, false);
+            for (const building of placedBuildings) {
+                this.applySpawnState(building);
+                this.makeBuildingSuperWeaponReady(building);
+                spawned.push(building);
+            }
+        }
+        if (spawned.length && owner === runtime.localPlayer) {
+            runtime.game.unitSelection.deselectAll();
+            spawned.forEach((building) => runtime.game.unitSelection.addToSelection(building));
+        }
+        this.state.spawnedCount += spawned.length;
+        this.setStatus(`已生成 ${spawned.length} 个 ${objectLabel}（${this.state.objectName}）@ ${targetTile.rx},${targetTile.ry}。`);
+        this.keepSandboxPlayersActive(runtime.game, runtime.localPlayer, runtime.enemyPlayer);
+        this.syncControls();
+        return spawned.length;
+    }
+
+    private static findBuildingSpawnTile(targetTile: any, worker: any, buildingName: string, offset: number): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        const canPlaceAtTile = (tile: any) => {
+            try {
+                return worker.canPlaceAt(buildingName, tile, { ignoreAdjacent: true });
+            }
+            catch {
+                return false;
+            }
+        };
+        if (offset === 0 && canPlaceAtTile(targetTile)) {
+            return targetTile;
+        }
+        const foundation = runtime.game.art.getObject(buildingName, ObjectType.Building).foundation;
+        const finder = new RadialTileFinder(
+            runtime.game.map.tiles,
+            runtime.game.map.mapBounds,
+            targetTile,
+            foundation,
+            Math.max(0, offset > 0 ? 1 : 0),
+            18,
+            canPlaceAtTile,
+        );
+        return finder.getNextTile();
+    }
+
+    private static findSpawnTile(targetTile: any, unit: any, offset: number): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return undefined;
+        }
+        const canSpawnAtTile = (tile: any) => {
+            if (!runtime.game.map.mapBounds.isWithinBounds(tile)) {
+                return false;
+            }
+            const bridge = this.getBridgeForUnit(unit, tile);
+            if (runtime.game.map.tileOccupation.getObjectsOnTile(tile).some((obj: any) => obj.isTechno?.() &&
+                obj.zone === unit.zone &&
+                !!obj.onBridge === !!bridge)) {
+                return false;
+            }
+            if (unit.rules.speedType === undefined || unit.zone === ZoneType.Air) {
+                return true;
+            }
+            return runtime.game.map.terrain.getPassableSpeed(tile, unit.rules.speedType, unit.isInfantry?.() ?? false, !!bridge) > 0 &&
+                !runtime.game.map.terrain.findObstacles({ tile, onBridge: bridge }, unit).length;
+        };
+        if (offset === 0 && canSpawnAtTile(targetTile)) {
+            return targetTile;
+        }
+        const finder = new RadialTileFinder(
+            runtime.game.map.tiles,
+            runtime.game.map.mapBounds,
+            targetTile,
+            unit.getFoundation?.() ?? { width: 1, height: 1 },
+            Math.max(0, offset > 0 ? 1 : 0),
+            10,
+            canSpawnAtTile,
+        );
+        return finder.getNextTile();
+    }
+
+    private static getBridgeForUnit(unit: any, tile: any): any | undefined {
+        const runtime = this.runtime;
+        if (!runtime || unit.zone === ZoneType.Air || Target.usesGroundLayerUnderBridge(unit)) {
+            return undefined;
+        }
+        return runtime.game.map.tileOccupation.getBridgeOnTile(tile);
+    }
+
+    private static applySpawnLayer(unit: any, tile: any): void {
+        if (unit.zone === ZoneType.Air) {
+            return;
+        }
+        const bridge = this.getBridgeForUnit(unit, tile);
+        unit.onBridge = !!bridge;
+        unit.zone = getZoneType(bridge ? tile.onBridgeLandType : tile.landType);
+        unit.position.tileElevation = bridge?.tileElevation ?? 0;
+    }
+
+    private static applySpawnState(unit: any): void {
+        if (unit.veteranTrait?.setVeteranLevel) {
+            unit.veteranTrait.setVeteranLevel(this.state.veteranLevel);
+        }
+        if (unit.healthTrait) {
+            unit.healthTrait.health = this.state.health === 'full'
+                ? 100
+                : this.state.health === 'half'
+                    ? 50
+                    : 20;
+        }
+    }
+
+    private static makeBuildingSuperWeaponReady(building: any): void {
+        const superWeapon = building.superWeaponTrait?.getSuperWeapon?.(building);
+        if (superWeapon) {
+            this.makeSuperWeaponReady(superWeapon);
+        }
+    }
+
+    private static clearSpawnedObjects(): void {
+        const runtime = this.runtime;
+        if (!runtime) {
+            return;
+        }
+        const objects = runtime.game.world.getAllObjects()
+            .filter((obj: any) => obj.isTechno?.() &&
+            (obj.isUnit?.() || obj.isBuilding?.()) &&
+            (obj.owner === runtime.localPlayer || obj.owner === runtime.enemyPlayer));
+        for (const obj of objects) {
+            try {
+                runtime.game.unspawnObject(obj);
+                obj.dispose?.();
+            }
+            catch (error) {
+                console.warn('[SceneSandboxTester] Failed to clear object', obj, error);
+            }
+        }
+        runtime.game.unitSelection.deselectAll();
+        this.state.spawnedCount = 0;
+        this.setStatus('已清空沙盒生成的单位和建筑。');
+        this.syncControls();
+    }
+
+    private static objectTypeForKind(kind: SpawnKind): ObjectType {
+        switch (kind) {
+            case 'infantry':
+                return ObjectType.Infantry;
+            case 'aircraft':
+                return ObjectType.Aircraft;
+            case 'building':
+            case 'superweapon':
+                return ObjectType.Building;
+            case 'naval':
+            default:
+                return ObjectType.Vehicle;
+        }
+    }
+
+    private static setStatus(message: string): void {
+        this.state.lastMessage = message;
+        this.updateStatus();
+        this.syncState();
+    }
+
+    private static updateStatus(): void {
+        const statusEl = this.runtime?.statusEl ?? document.querySelector('[data-testid="sandbox-status"]') as HTMLDivElement | null;
+        if (!statusEl) {
+            return;
+        }
+        statusEl.textContent = [
+            this.state.lastMessage,
+            `已生成：${this.state.spawnedCount}`,
+            `速度：${this.state.tickMultiplier}x`,
+            this.state.placementActive
+                ? '当前：放置模式'
+                : this.state.demolitionActive
+                    ? '当前：拆除建筑'
+                    : this.state.superWeaponTargetingActive
+                        ? '当前：超级武器瞄准'
+                        : '当前：正常交互',
+        ].join('\n');
+    }
+
+    private static syncState(): void {
+        TestToolSupport.setState('scene-sandbox', {
+            kind: this.state.kind,
+            objectName: this.state.objectName,
+            owner: this.state.owner,
+            veteranLevel: VeteranLevel[this.state.veteranLevel],
+            health: this.state.health,
+            count: this.state.count,
+            placementActive: this.state.placementActive,
+            demolitionActive: this.state.demolitionActive,
+            superWeaponTargetingActive: this.state.superWeaponTargetingActive,
+            activeSuperWeaponName: this.state.activeSuperWeaponName,
+            panelCollapsed: this.state.panelCollapsed,
+            tickMultiplier: this.state.tickMultiplier,
+            spawnedCount: this.state.spawnedCount,
+            message: this.state.lastMessage,
+        });
+    }
+
+    private static removeBaseUnits(game: any, localPlayer: any, enemyPlayer: any): void {
+        for (const player of [localPlayer, enemyPlayer]) {
+            for (const obj of [...player.getOwnedObjects()]) {
+                if (!obj.isUnit?.()) {
+                    continue;
+                }
+                try {
+                    game.unspawnObject(obj);
+                    obj.dispose?.();
+                }
+                catch (error) {
+                    console.warn('[SceneSandboxTester] Failed to remove starting unit', obj, error);
+                }
+            }
+        }
+    }
+
+    private static disableSandboxEndConditions(game: any, localPlayer: any, enemyPlayer: any): void {
+        game.checkGameEndConditions = () => undefined;
+        game.updateDefeatedPlayers = () => undefined;
+        this.keepSandboxPlayersActive(game, localPlayer, enemyPlayer);
+    }
+
+    private static keepSandboxPlayersActive(_game: any, localPlayer: any, enemyPlayer: any): void {
+        for (const player of [localPlayer, enemyPlayer]) {
+            player.defeated = false;
+            player.isObserver = false;
+        }
+    }
+
+    private static layoutMinimap(minimap: Minimap, viewport: { width: number; height: number }): void {
+        const size = Math.max(120, Math.min(180, Math.floor(Math.min(viewport.width, viewport.height) * 0.22)));
+        minimap.setFitSize({ width: size, height: size });
+        minimap.setPosition(viewport.width - size - 16, 16);
+        minimap.setZIndex(20);
+    }
+
+    private static getViewport(): { x: number; y: number; width: number; height: number } {
+        return {
+            x: 0,
+            y: 0,
+            width: Math.max(1024, window.innerWidth || 1024),
+            height: Math.max(700, window.innerHeight || 700),
+        };
+    }
+
+    private static findNamedIndex(values: string[], preferred: string[]): string {
+        const lowered = values.map((value) => value.toLowerCase());
+        for (const name of preferred) {
+            const index = lowered.indexOf(name.toLowerCase());
+            if (index >= 0) {
+                return String(index);
+            }
+        }
+        return '0';
+    }
+
+    static destroy(): void {
+        TestToolSupport.clearState('scene-sandbox');
+        if (this.gameTickTimer) {
+            clearInterval(this.gameTickTimer);
+            this.gameTickTimer = undefined;
+        }
+        this.uiAnimationLoop?.destroy();
+        this.uiAnimationLoop = undefined;
+        this.renderer?.dispose();
+        this.renderer = undefined;
+        this.runtime = undefined;
+        this.shiftPlacementActive = false;
+        this.state.demolitionActive = false;
+        this.disposables.dispose();
+    }
+}


### PR DESCRIPTION
## 新增
- **场景沙盒（Scene Sandbox）**：在真实官方地图上手动放置各种单位 / 船只 / 步兵 / 飞行器 / 建筑 / 超级武器，用来测试单位交互（含桥梁移动 / 登载）。可设置归属、老兵等级、血量、数量；支持进入放置模式后左键放置、拆除建筑、触发超级武器、调节速度、回到基地视角、快捷键下令等。

  **入口（两种任选）：**
  - 直接在地址栏访问 `#/scenesandbox`，例如 `https://<host>/#/scenesandbox`（开发路由，需已载入游戏资源）；
  - 或：主菜单 →「测试入口」页（`MainMenuScreenType.TestEntry`）→ 点最上方的 **「场景沙盒」** 按钮（按钮会跳到 `#/scenesandbox`）。

  加载时优先用 `mp18s3.map`，找不到则回退 `mp03t4.map`。

## 修复
- 陆军 / 坦克现在能正确移动上桥（之前移动指令会被静默丢弃）。
- 海军单位可以顺利通过高桥、驶到 / 停在桥正下方的水面，并在桥下时被桥面正确遮挡。
- 桥上的单位不能再跨层登载下方水里的运输艇。
- 修复高桥边缘点不到的死区。

## 已知问题
- 船只移动到桥正下方时，部分位置仍点不中（拾取还有死角，待后续优化）。