### PR TITLE
修复飞行单位飞过高桥被遮挡 + 沙盒改回左键移动

### DIFF
--- a/src/engine/renderable/entity/Infantry.ts
+++ b/src/engine/renderable/entity/Infantry.ts
@@ -478,7 +478,10 @@ export class Infantry {
         }
     }
     private updateBridgeRenderOrder(): void {
-        const renderOrder = this.gameObject.onBridge ? 2 : 0;
+        // Airborne units (jumpjet rocketeers etc.) fly OVER a high bridge, so they must
+        // render above its deck (renderOrder 1); without the Air check they'd get
+        // renderOrder 0 and be drawn behind the bridge — looking like they went under it.
+        const renderOrder = (this.gameObject.onBridge || this.gameObject.zone === ZoneType.Air) ? 2 : 0;
         if (this.lastBridgeRenderOrder === renderOrder) {
             return;
         }

--- a/src/engine/renderable/entity/Vehicle.ts
+++ b/src/engine/renderable/entity/Vehicle.ts
@@ -666,7 +666,9 @@ export class Vehicle {
         (a.matrixAutoUpdate = !1), a.add(e), t.add(a);
     }
     updateBridgeRenderOrder() {
-        const renderOrder = this.gameObject.onBridge ? 2 : 0;
+        // Airborne units (aircraft) fly OVER a high bridge and must render above its
+        // deck; without the Air check they'd be drawn behind the bridge.
+        const renderOrder = (this.gameObject.onBridge || this.gameObject.zone === M.ZoneType.Air) ? 2 : 0;
         if (this.lastBridgeRenderOrder === renderOrder) {
             return;
         }

--- a/src/tools/SceneSandboxTester.ts
+++ b/src/tools/SceneSandboxTester.ts
@@ -229,8 +229,9 @@ export class SceneSandboxTester {
         this.disposables.add(canvasMetrics);
 
         const generalOptions = new GeneralOptions();
-        generalOptions.rightClickMove.value = true;
-        generalOptions.rightClickScroll.value = false;
+        // RA2 风格：左键移动、右键拖动卷动地图（与真实游戏默认一致）。
+        generalOptions.rightClickMove.value = false;
+        generalOptions.rightClickScroll.value = true;
         generalOptions.targetLines.value = true;
         const runtimeVars = new ConsoleVars();
         runtimeVars.freeCamera.value = false;


### PR DESCRIPTION
基于已合并的 #50 的两处后续修复。

## 修复
- 飞行单位（火箭飞行兵、飞机等，airborne 时 `zone === Air`）飞过**高桥**时现在渲染在桥面之上，不再被桥面遮挡（之前 `renderOrder = 0` 排在高桥的 `1` 之下，看起来像钻到桥下面去了）。Infantry 与 Vehicle 同修。
- 场景沙盒改回 **RA2 风格**：左键移动、右键拖动卷动地图（之前被强制成了右键移动）。放置模式下世界交互本就会被禁用，左键放置不冲突。